### PR TITLE
remove docker compose deprecated stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ Steps to run this demo are as follows:
 
 ```bash
 # run CrowdSec container
-$ docker-compose up -d crowdsec
+$ docker compose up -d crowdsec
 
 # add the Caddy bouncer, generating an API key
-$ docker-compose exec crowdsec cscli bouncers add caddy-bouncer
+$ docker compose exec crowdsec cscli bouncers add caddy-bouncer
 
 # copy and paste the API key in the ./docker/config.json file
 # below is the git diff after changing the appropriate line:
@@ -196,10 +196,10 @@ $ git diff
 + "api_key": "9e4ac94cf9aebaa3625a1d51951230a9",
 
 # run Caddy; at first run a custom build will be created using xcaddy
-$ docker-compose up -d caddy
+$ docker compose up -d caddy
 
 # tail the logs
-$ docker-compose logs -tf
+$ docker compose logs -tf
 ```
 
 You can then access https://localhost:9443 and https://localhost:8443.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,3 @@
-version: "3.4"
-
-volumes:
-  caddy-data: {}
-  caddy-config: {}
-  logs: {}
-
 services:
   crowdsec:
     image: crowdsecurity/crowdsec
@@ -25,3 +18,8 @@ services:
       - caddy-config:/config
       - logs:/var/log/caddy
       - ./docker/config.json:/etc/caddy/config.json
+
+volumes:
+  caddy-data:
+  caddy-config:
+  logs:


### PR DESCRIPTION
- remove `version` key as it is deprecated (https://github.com/docker/compose/issues/11628#issuecomment-2000072567)
- `docker-compose` is deprecated as well and now it's `docker compose` (plugin instead of a binary)