### PR TITLE
Fix potential uninitialized usage of APIClient for metrics provider

### DIFF
--- a/internal/bouncer/bouncer.go
+++ b/internal/bouncer/bouncer.go
@@ -142,7 +142,7 @@ func (b *Bouncer) Init() (err error) {
 	// TODO: make metrics gathering/integration optional? I.e. if the metrics
 	// interval is configured to be 0 or smaller, don't start the metrics
 	// provider? Separate setting for gathering metrics vs. pushing to LAPI?
-	metricsInterval := 0 * time.Minute // 1 * time.Minute
+	metricsInterval := 1 * time.Minute
 
 	// conditionally initialize the CrowdSec live bouncer
 	if !b.useStreamingBouncer {
@@ -166,7 +166,7 @@ func (b *Bouncer) Init() (err error) {
 		}
 	}
 
-	if b.metricsProvider, err = newMetricsProvider(b.streamingBouncer.APIClient, b.updateMetrics, metricsInterval); err != nil {
+	if b.metricsProvider, err = newMetricsProvider(b.liveBouncer.APIClient, b.updateMetrics, metricsInterval); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If the streaming bouncer is not used, it will never get initialized. This ends up causing the metrics provider to use an `APIClient` with the wrong values configured. Use the liveBouncer's `APIClient` instead, as it's guaranteed to be initialized.

I suspect this is the cause of https://github.com/hslatman/caddy-crowdsec-bouncer/issues/59 but I have not had a chance to test this yet.
