### PR TITLE
Refactor API client and bouncer initialization

### DIFF
--- a/crowdsec/admin.go
+++ b/crowdsec/admin.go
@@ -33,6 +33,6 @@ func (c *CrowdSec) Ping(ctx context.Context) bool {
 	return b
 }
 
-func (c *CrowdSec) Check(_ context.Context, ip netip.Addr, forceLive bool) (bool, *models.Decision, error) {
-	return c.core.IsAllowed(ip, forceLive, "check")
+func (c *CrowdSec) Check(ctx context.Context, ip netip.Addr, forceLive bool) (bool, *models.Decision, error) {
+	return c.core.IsAllowed(ctx, ip, forceLive, "check")
 }

--- a/crowdsec/crowdsec.go
+++ b/crowdsec/crowdsec.go
@@ -133,17 +133,10 @@ func (c *CrowdSec) Provision(ctx caddy.Context) error {
 	if c.enableCaddyMetrics() {
 		registry = ctx.GetMetricsRegistry()
 	}
-	core, err := core.New(c.APIKey, c.APIUrl, c.AppSecUrl, c.AppSecMaxBodySize, c.appSecTimeout(), c.isAppSecFailOpenEnabled(), c.tickerInterval(), c.logger, registry, c.metricsInterval())
+
+	core, err := core.New(c.APIKey, c.APIUrl, c.isStreamingEnabled(), c.AppSecUrl, c.AppSecMaxBodySize, c.appSecTimeout(), c.isAppSecFailOpenEnabled(), c.tickerInterval(), c.shouldFailHard(), c.logger, registry, c.metricsInterval())
 	if err != nil {
 		return err
-	}
-
-	if c.isStreamingEnabled() {
-		core.EnableStreaming()
-	}
-
-	if c.shouldFailHard() {
-		core.EnableHardFails()
 	}
 
 	c.core = core
@@ -346,7 +339,7 @@ func (c *CrowdSec) tickerInterval() time.Duration {
 		}
 	}
 
-	return 60 * time.Second // return the default in case parsing fails; validation happens before
+	return 60 * time.Second // return the default in case parsing fails
 }
 
 func (c *CrowdSec) enableCaddyMetrics() bool {

--- a/crowdsec/crowdsec.go
+++ b/crowdsec/crowdsec.go
@@ -156,8 +156,12 @@ func (c *CrowdSec) Validate() error {
 		return fmt.Errorf("failed checking CrowdSec modules: %w", err)
 	}
 	if interval := c.TickerInterval; interval != "" {
-		if _, err := time.ParseDuration(interval); err != nil {
+		d, err := time.ParseDuration(interval)
+		if err != nil {
 			return fmt.Errorf("invalid ticker interval %q", interval)
+		}
+		if d <= 0 {
+			return errors.New("ticker interval must be positive")
 		}
 	}
 

--- a/crowdsec/crowdsec.go
+++ b/crowdsec/crowdsec.go
@@ -112,7 +112,9 @@ type CrowdSec struct {
 func (c *CrowdSec) Provision(ctx caddy.Context) error {
 	c.ctx = ctx
 	c.logger = ctx.Logger(c)
-	defer c.logger.Sync() // nolint
+	defer func() {
+		_ = c.logger.Sync()
+	}()
 
 	repl := caddy.NewReplacer() // create replacer with the default, global replacement functions, including ".env" env var reading
 	c.APIUrl = repl.ReplaceKnown(c.APIUrl, "")
@@ -288,7 +290,7 @@ func (c *CrowdSec) Cleanup() error {
 		return nil
 	}
 
-	_ = c.logger.Sync() // nolint
+	_ = c.logger.Sync()
 
 	return nil
 }
@@ -311,8 +313,8 @@ func (c *CrowdSec) Stop() error {
 
 // IsAllowed is used by the CrowdSec HTTP handler to check if
 // an IP is allowed to perform a request.
-func (c *CrowdSec) IsAllowed(ip netip.Addr) (bool, *models.Decision, error) {
-	return c.core.IsAllowed(ip, false, "")
+func (c *CrowdSec) IsAllowed(ctx context.Context, ip netip.Addr) (bool, *models.Decision, error) {
+	return c.core.IsAllowed(ctx, ip, false, "")
 }
 
 // CheckRequest checks the incoming request against AppSec.

--- a/crowdsec/crowdsec.go
+++ b/crowdsec/crowdsec.go
@@ -133,7 +133,7 @@ func (c *CrowdSec) Provision(ctx caddy.Context) error {
 	if c.enableCaddyMetrics() {
 		registry = ctx.GetMetricsRegistry()
 	}
-	core, err := core.New(c.APIKey, c.APIUrl, c.AppSecUrl, c.AppSecMaxBodySize, c.appSecTimeout(), c.isAppSecFailOpenEnabled(), c.TickerInterval, c.logger, registry, c.metricsInterval())
+	core, err := core.New(c.APIKey, c.APIUrl, c.AppSecUrl, c.AppSecMaxBodySize, c.appSecTimeout(), c.isAppSecFailOpenEnabled(), c.tickerInterval(), c.logger, registry, c.metricsInterval())
 	if err != nil {
 		return err
 	}
@@ -161,6 +161,11 @@ func (c *CrowdSec) Validate() error {
 	}
 	if err := c.checkModules(); err != nil {
 		return fmt.Errorf("failed checking CrowdSec modules: %w", err)
+	}
+	if interval := c.TickerInterval; interval != "" {
+		if _, err := time.ParseDuration(interval); err != nil {
+			return fmt.Errorf("invalid ticker interval %q", interval)
+		}
 	}
 
 	return nil
@@ -332,6 +337,16 @@ func (c *CrowdSec) IncrementBlockedRequests(server, origin, remediation string, 
 
 func (c *CrowdSec) metricsInterval() time.Duration {
 	return time.Duration(c.MetricsInterval)
+}
+
+func (c *CrowdSec) tickerInterval() time.Duration {
+	if interval := c.TickerInterval; interval != "" {
+		if d, err := time.ParseDuration(interval); err == nil {
+			return d
+		}
+	}
+
+	return 60 * time.Second // return the default in case parsing fails; validation happens before
 }
 
 func (c *CrowdSec) enableCaddyMetrics() bool {

--- a/crowdsec/crowdsec_test.go
+++ b/crowdsec/crowdsec_test.go
@@ -212,7 +212,7 @@ func TestCrowdSecStreamingBouncerRuntime(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		// simulate request coming in and stopping the server from another goroutine
-		allowed, decision, err := c.IsAllowed(netip.MustParseAddr("127.0.0.1"))
+		allowed, decision, err := c.IsAllowed(t.Context(), netip.MustParseAddr("127.0.0.1"))
 		assert.NoError(t, err)
 		assert.Nil(t, decision)
 		assert.True(t, allowed)
@@ -265,7 +265,7 @@ func TestCrowdSecliveBouncerRuntime(t *testing.T) {
 	require.NoError(t, err)
 
 	// simulate a lookup
-	allowed, decision, err := c.IsAllowed(netip.MustParseAddr("127.0.0.1"))
+	allowed, decision, err := c.IsAllowed(t.Context(), netip.MustParseAddr("127.0.0.1"))
 	assert.NoError(t, err)
 	assert.Nil(t, decision)
 	assert.True(t, allowed)

--- a/http/http.go
+++ b/http/http.go
@@ -79,7 +79,7 @@ func (h *Handler) Cleanup() error {
 		return nil
 	}
 
-	_ = h.logger.Sync() // nolint
+	_ = h.logger.Sync()
 
 	return nil
 }
@@ -96,7 +96,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	ctx, ip = httputils.EnsureIP(ctx)
 	ctx = h.crowdsec.IncrementProcessedRequests(ctx, server, module, ip.Is6())
 
-	isAllowed, decision, err := h.crowdsec.IsAllowed(ip)
+	isAllowed, decision, err := h.crowdsec.IsAllowed(ctx, ip)
 	if err != nil {
 		return err // TODO: return error here? Or just log it and continue serving
 	}

--- a/internal/bouncer/client.go
+++ b/internal/bouncer/client.go
@@ -2,7 +2,6 @@ package bouncer
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,14 +14,6 @@ import (
 
 func NewAPIClient(urlstr string, apiKey string, userAgent string, caPath string, certPath string, keyPath string, skipVerify *bool, logger logrus.FieldLogger) (*apiclient.ApiClient, error) {
 	var client *http.Client
-
-	if apiKey == "" && certPath == "" && keyPath == "" {
-		return nil, errors.New("no API key nor certificate provided")
-	}
-
-	if apiKey != "" && (certPath != "" || keyPath != "") {
-		return nil, fmt.Errorf("cannot use both API key and certificate auth")
-	}
 
 	insecureSkipVerify := false
 

--- a/internal/bouncer/client.go
+++ b/internal/bouncer/client.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 )
 
-func getAPIClient(urlstr string, userAgent string, apiKey string, caPath string, certPath string, keyPath string, skipVerify *bool, logger logrus.FieldLogger) (*apiclient.ApiClient, error) {
+func NewAPIClient(urlstr string, apiKey string, userAgent string, caPath string, certPath string, keyPath string, skipVerify *bool, logger logrus.FieldLogger) (*apiclient.ApiClient, error) {
 	var client *http.Client
 
 	if apiKey == "" && certPath == "" && keyPath == "" {
@@ -24,6 +25,10 @@ func getAPIClient(urlstr string, userAgent string, apiKey string, caPath string,
 	}
 
 	insecureSkipVerify := false
+
+	if !strings.HasSuffix(urlstr, "/") {
+		urlstr += "/"
+	}
 
 	apiURL, err := url.Parse(urlstr)
 	if err != nil {

--- a/internal/bouncer/live.go
+++ b/internal/bouncer/live.go
@@ -15,11 +15,11 @@ type LiveBouncer struct {
 	metricsProvider *metrics.Provider
 }
 
-func NewLiveBouncer(a *apiclient.ApiClient, m *metrics.Provider) (*LiveBouncer, error) {
+func NewLiveBouncer(a *apiclient.ApiClient, m *metrics.Provider) *LiveBouncer {
 	return &LiveBouncer{
 		apiClient:       a,
 		metricsProvider: m,
-	}, nil
+	}
 }
 
 func (b *LiveBouncer) Get(ctx context.Context, value, method string) (*models.GetDecisionsResponse, error) {

--- a/internal/bouncer/live.go
+++ b/internal/bouncer/live.go
@@ -2,55 +2,26 @@ package bouncer
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hslatman/caddy-crowdsec-bouncer/internal/metrics"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 )
 
 type LiveBouncer struct {
-	APIKey             string `yaml:"api_key"`
-	APIUrl             string `yaml:"api_url"`
-	InsecureSkipVerify *bool  `yaml:"insecure_skip_verify"`
-	CertPath           string `yaml:"cert_path"`
-	KeyPath            string `yaml:"key_path"`
-	CAPath             string `yaml:"ca_cert_path"`
-
-	APIClient       *apiclient.ApiClient
-	UserAgent       string
-	MetricsProvider *metrics.Provider
+	apiClient       *apiclient.ApiClient
+	metricsProvider *metrics.Provider
 }
 
-func (b *LiveBouncer) Init() error {
-	var err error
-
-	// validate the configuration
-
-	if b.APIUrl == "" {
-		return fmt.Errorf("config does not contain LAPI url")
-	}
-
-	if !strings.HasSuffix(b.APIUrl, "/") {
-		b.APIUrl += "/"
-	}
-
-	if b.APIKey == "" && b.CertPath == "" && b.KeyPath == "" {
-		return fmt.Errorf("config does not contain LAPI key or certificate")
-	}
-
-	b.APIClient, err = getAPIClient(b.APIUrl, b.UserAgent, b.APIKey, b.CAPath, b.CertPath, b.KeyPath, b.InsecureSkipVerify, log.StandardLogger())
-	if err != nil {
-		return fmt.Errorf("api client init: %w", err)
-	}
-	return nil
+func NewLiveBouncer(a *apiclient.ApiClient, m *metrics.Provider) (*LiveBouncer, error) {
+	return &LiveBouncer{
+		apiClient:       a,
+		metricsProvider: m,
+	}, nil
 }
 
-// TODO: plumb context.Context
 func (b *LiveBouncer) Get(ctx context.Context, value, method string) (*models.GetDecisionsResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -69,10 +40,10 @@ func (b *LiveBouncer) Get(ctx context.Context, value, method string) (*models.Ge
 		mode = modeLive
 	}
 
-	b.MetricsProvider.IncrementTotalBouncerCalls(mode)
-	decision, resp, err := b.APIClient.Decisions.List(ctx, filter)
+	b.metricsProvider.IncrementTotalBouncerCalls(mode)
+	decision, resp, err := b.apiClient.Decisions.List(ctx, filter)
 	if err != nil {
-		b.MetricsProvider.IncrementTotalBouncerErrors(mode)
+		b.metricsProvider.IncrementTotalBouncerErrors(mode)
 		if resp != nil && resp.Response != nil {
 			_ = resp.Response.Body.Close()
 		}

--- a/internal/bouncer/live.go
+++ b/internal/bouncer/live.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hslatman/caddy-crowdsec-bouncer/internal/metrics"
 	log "github.com/sirupsen/logrus"
@@ -50,7 +51,10 @@ func (b *LiveBouncer) Init() error {
 }
 
 // TODO: plumb context.Context
-func (b *LiveBouncer) Get(value, method string) (*models.GetDecisionsResponse, error) {
+func (b *LiveBouncer) Get(ctx context.Context, value, method string) (*models.GetDecisionsResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	filter := apiclient.DecisionsListOpts{
 		IPEquals: &value,
 	}
@@ -66,7 +70,7 @@ func (b *LiveBouncer) Get(value, method string) (*models.GetDecisionsResponse, e
 	}
 
 	b.MetricsProvider.IncrementTotalBouncerCalls(mode)
-	decision, resp, err := b.APIClient.Decisions.List(context.Background(), filter)
+	decision, resp, err := b.APIClient.Decisions.List(ctx, filter)
 	if err != nil {
 		b.MetricsProvider.IncrementTotalBouncerErrors(mode)
 		if resp != nil && resp.Response != nil {

--- a/internal/bouncer/stream.go
+++ b/internal/bouncer/stream.go
@@ -2,6 +2,7 @@ package bouncer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -96,6 +97,7 @@ func (b *StreamBouncer) Init() error {
 	if err != nil {
 		return fmt.Errorf("api client init: %w", err)
 	}
+
 	return nil
 }
 
@@ -107,22 +109,18 @@ const (
 )
 
 func (b *StreamBouncer) Run(ctx context.Context) {
+	defer func() {
+		log.Warn("running defer; closing stream?")
+	}()
+	defer close(b.Stream)
+
 	ticker := time.NewTicker(b.TickerIntervalDuration)
 
 	b.Opts.Startup = true
 
-	getDecisionStream := func() (*models.DecisionsStreamResponse, *apiclient.Response, error) {
-		data, resp, err := b.APIClient.Decisions.GetStream(context.Background(), b.Opts)
-		b.MetricsProvider.IncrementTotalBouncerCalls(modeStream)
-		if err != nil {
-			b.MetricsProvider.IncrementTotalBouncerErrors(modeStream)
-		}
-		return data, resp, err
-	}
-
 	// Initial connection
 	for {
-		data, resp, err := getDecisionStream()
+		data, resp, err := b.getDecisionStream(ctx, b.Opts)
 
 		if resp != nil && resp.Response != nil {
 			_ = resp.Response.Body.Close()
@@ -133,7 +131,9 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 				log.Errorf("failed to connect to LAPI, retrying in 10s: %s", err)
 				select {
 				case <-ctx.Done():
-					// context cancellation, possibly a SIGTERM
+					if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
+						log.Error(err)
+					}
 					return
 				case <-time.After(10 * time.Second):
 					continue
@@ -141,9 +141,6 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 			}
 
 			log.Error(err)
-			// close the stream
-			// this may cause the bouncer to exit
-			close(b.Stream)
 			return
 		}
 
@@ -155,9 +152,12 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			if err := ctx.Err(); err != nil && !errors.Is(err, context.Canceled) {
+				log.Error(err)
+			}
 			return
 		case <-ticker.C:
-			data, resp, err := getDecisionStream()
+			data, resp, err := b.getDecisionStream(ctx, b.Opts)
 			if resp != nil && resp.Response != nil {
 				_ = resp.Response.Body.Close()
 			}
@@ -168,4 +168,17 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 			b.Stream <- data
 		}
 	}
+}
+
+func (b *StreamBouncer) getDecisionStream(ctx context.Context, opts apiclient.DecisionsStreamOpts) (*models.DecisionsStreamResponse, *apiclient.Response, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	b.MetricsProvider.IncrementTotalBouncerCalls(modeStream)
+	data, resp, err := b.APIClient.Decisions.GetStream(ctx, opts)
+	if err != nil {
+		b.MetricsProvider.IncrementTotalBouncerErrors(modeStream)
+	}
+
+	return data, resp, err
 }

--- a/internal/bouncer/stream.go
+++ b/internal/bouncer/stream.go
@@ -79,7 +79,14 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 			return
 		}
 
-		b.Stream <- data
+		// Guard the send: on shutdown the consumer (Core.startProcessingDecisions)
+		// returns on ctx.Done(), so an unguarded send here would block forever and
+		// deadlock Core.Shutdown's wg.Wait().
+		select {
+		case b.Stream <- data:
+		case <-ctx.Done():
+			return
+		}
 		break
 	}
 
@@ -100,7 +107,13 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 				log.Error(err)
 				continue
 			}
-			b.Stream <- data
+			// Guard the send so a shutdown mid-loop can't block on a consumer
+			// that has already returned on ctx.Done().
+			select {
+			case b.Stream <- data:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }

--- a/internal/bouncer/stream.go
+++ b/internal/bouncer/stream.go
@@ -44,9 +44,6 @@ const (
 )
 
 func (b *StreamBouncer) Run(ctx context.Context) {
-	defer func() {
-		log.Warn("running defer; closing stream?")
-	}()
 	defer close(b.Stream)
 
 	ticker := time.NewTicker(b.tickerInterval)

--- a/internal/bouncer/stream.go
+++ b/internal/bouncer/stream.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
@@ -15,90 +14,26 @@ import (
 )
 
 type StreamBouncer struct {
-	APIKey              string `yaml:"api_key"`
-	APIUrl              string `yaml:"api_url"`
-	InsecureSkipVerify  *bool  `yaml:"insecure_skip_verify"`
-	CertPath            string `yaml:"cert_path"`
-	KeyPath             string `yaml:"key_path"`
-	CAPath              string `yaml:"ca_cert_path"`
-	RetryInitialConnect bool   `yaml:"retry_initial_connect"`
-
-	TickerInterval         string   `yaml:"update_frequency"`
-	Scopes                 []string `yaml:"scopes"`
-	ScenariosContaining    []string `yaml:"scenarios_containing"`
-	ScenariosNotContaining []string `yaml:"scenarios_not_containing"`
-	Origins                []string `yaml:"origins"`
-
-	TickerIntervalDuration time.Duration
-	Stream                 chan *models.DecisionsStreamResponse
-	APIClient              *apiclient.ApiClient
-	UserAgent              string
-	Opts                   apiclient.DecisionsStreamOpts
-
-	MetricsProvider *metrics.Provider
+	apiClient           *apiclient.ApiClient
+	metricsProvider     *metrics.Provider
+	tickerInterval      time.Duration
+	RetryInitialConnect bool
+	opts                apiclient.DecisionsStreamOpts
+	Stream              chan *models.DecisionsStreamResponse
 }
 
-func (b *StreamBouncer) Init() error {
-	var err error
-
-	// validate the configuration
-
-	if b.APIUrl == "" {
-		return fmt.Errorf("config does not contain LAPI url")
+func NewStreamBouncer(a *apiclient.ApiClient, m *metrics.Provider, tickerInterval time.Duration, retryInitialConnect bool) (*StreamBouncer, error) {
+	if tickerInterval <= 0 {
+		return nil, fmt.Errorf("lapi update interval must be positive")
 	}
 
-	if !strings.HasSuffix(b.APIUrl, "/") {
-		b.APIUrl += "/"
-	}
-
-	if b.APIKey == "" && b.CertPath == "" && b.KeyPath == "" {
-		return fmt.Errorf("config does not contain LAPI key or certificate")
-	}
-
-	//  scopes, origins, etc.
-
-	if b.Scopes != nil {
-		b.Opts.Scopes = strings.Join(b.Scopes, ",")
-	}
-
-	if b.ScenariosContaining != nil {
-		b.Opts.ScenariosContaining = strings.Join(b.ScenariosContaining, ",")
-	}
-
-	if b.ScenariosNotContaining != nil {
-		b.Opts.ScenariosNotContaining = strings.Join(b.ScenariosNotContaining, ",")
-	}
-
-	if b.Origins != nil {
-		b.Opts.Origins = strings.Join(b.Origins, ",")
-	}
-
-	// update_frequency or however it's called in the .yaml of the specific bouncer
-
-	if b.TickerInterval == "" {
-		log.Warningf("lapi update interval is not defined, using default value of 10s")
-		b.TickerInterval = "10s"
-	}
-
-	b.TickerIntervalDuration, err = time.ParseDuration(b.TickerInterval)
-	if err != nil {
-		return fmt.Errorf("unable to parse lapi update interval '%s': %w", b.TickerInterval, err)
-	}
-
-	if b.TickerIntervalDuration <= 0 {
-		return fmt.Errorf("lapi update interval must be positive")
-	}
-
-	// prepare the client object for the lapi
-
-	b.Stream = make(chan *models.DecisionsStreamResponse)
-
-	b.APIClient, err = getAPIClient(b.APIUrl, b.UserAgent, b.APIKey, b.CAPath, b.CertPath, b.KeyPath, b.InsecureSkipVerify, log.StandardLogger())
-	if err != nil {
-		return fmt.Errorf("api client init: %w", err)
-	}
-
-	return nil
+	return &StreamBouncer{
+		apiClient:           a,
+		metricsProvider:     m,
+		tickerInterval:      tickerInterval,
+		RetryInitialConnect: retryInitialConnect,
+		Stream:              make(chan *models.DecisionsStreamResponse),
+	}, nil
 }
 
 const (
@@ -114,13 +49,13 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 	}()
 	defer close(b.Stream)
 
-	ticker := time.NewTicker(b.TickerIntervalDuration)
+	ticker := time.NewTicker(b.tickerInterval)
 
-	b.Opts.Startup = true
+	b.opts.Startup = true
 
 	// Initial connection
 	for {
-		data, resp, err := b.getDecisionStream(ctx, b.Opts)
+		data, resp, err := b.getDecisionStream(ctx, b.opts)
 
 		if resp != nil && resp.Response != nil {
 			_ = resp.Response.Body.Close()
@@ -148,7 +83,7 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 		break
 	}
 
-	b.Opts.Startup = false
+	b.opts.Startup = false
 	for {
 		select {
 		case <-ctx.Done():
@@ -157,7 +92,7 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 			}
 			return
 		case <-ticker.C:
-			data, resp, err := b.getDecisionStream(ctx, b.Opts)
+			data, resp, err := b.getDecisionStream(ctx, b.opts)
 			if resp != nil && resp.Response != nil {
 				_ = resp.Response.Body.Close()
 			}
@@ -174,11 +109,15 @@ func (b *StreamBouncer) getDecisionStream(ctx context.Context, opts apiclient.De
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	b.MetricsProvider.IncrementTotalBouncerCalls(modeStream)
-	data, resp, err := b.APIClient.Decisions.GetStream(ctx, opts)
+	b.metricsProvider.IncrementTotalBouncerCalls(modeStream)
+	data, resp, err := b.apiClient.Decisions.GetStream(ctx, opts)
 	if err != nil {
-		b.MetricsProvider.IncrementTotalBouncerErrors(modeStream)
+		b.metricsProvider.IncrementTotalBouncerErrors(modeStream)
 	}
 
 	return data, resp, err
+}
+
+func (b *StreamBouncer) SetAPIClientForTesting(a *apiclient.ApiClient) {
+	b.apiClient = a
 }

--- a/internal/core/appsec.go
+++ b/internal/core/appsec.go
@@ -86,7 +86,6 @@ func (a *appsec) checkRequest(ctx context.Context, r *http.Request) error {
 		if a.maxBodySize > 0 {
 			len := min(len(originalBody), a.maxBodySize)
 			_, _ = buffer.Write(originalBody[:len])
-
 		} else {
 			_, _ = buffer.Write(originalBody)
 		}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -150,14 +150,6 @@ func (b *Core) Init() (err error) {
 	// override CrowdSec's default logrus logging
 	b.overrideLogrusLogger()
 
-	// conditionally initialize the CrowdSec live bouncer
-	if !b.useStreamingBouncer {
-		b.logger.Info("initializing live bouncer", b.zapField())
-		if err = b.liveBouncer.Init(); err != nil {
-			return err
-		}
-	}
-
 	// conditionally initialize the CrowdSec streaming bouncer. The
 	// live bouncer is also initialized for ad hoc live lookups.
 	if b.useStreamingBouncer {
@@ -167,6 +159,11 @@ func (b *Core) Init() (err error) {
 		}
 
 		b.logger.Info("initializing live bouncer for ad hoc live lookups", b.zapField())
+		if err = b.liveBouncer.Init(); err != nil {
+			return err
+		}
+	} else {
+		b.logger.Info("initializing live bouncer", b.zapField())
 		if err = b.liveBouncer.Init(); err != nil {
 			return err
 		}
@@ -230,23 +227,25 @@ func (b *Core) Shutdown() error {
 	b.cancel()
 	b.wg.Wait()
 
-	// TODO: clean shutdown of the streaming bouncer channel reading
-	//b.store = nil // TODO(hs): setting this to nil without reinstantiating it, leads to errors; do this properly.
+	// TODO: clean shutdown of the streaming bouncer channel writing/reading?
+
+	b.logger.Warn("setting store nil") // TODO: remove
+	b.store = nil
 
 	b.stopped = true
-	b.logger.Info("finished", b.zapField())
-	b.logger.Sync() // nolint
+	b.logger.Info("finished shutdown", b.zapField())
+	_ = b.logger.Sync()
 
 	return nil
 }
 
 // IsAllowed checks if an IP is allowed or not
-func (b *Core) IsAllowed(ip netip.Addr, forceLive bool, method string) (bool, *models.Decision, error) {
-	isAllowed, decision, err := b.isAllowed(ip, forceLive, method)
+func (b *Core) IsAllowed(ctx context.Context, ip netip.Addr, forceLive bool, method string) (bool, *models.Decision, error) {
+	isAllowed, decision, err := b.isAllowed(ctx, ip, forceLive, method)
 	return isAllowed, decision, err
 }
 
-func (b *Core) isAllowed(ip netip.Addr, forceLive bool, method string) (bool, *models.Decision, error) {
+func (b *Core) isAllowed(ctx context.Context, ip netip.Addr, forceLive bool, method string) (bool, *models.Decision, error) {
 	// TODO: perform lookup in explicit allowlist as a kind of quick lookup in front of the CrowdSec lookup list?
 	isAllowed := false
 
@@ -254,7 +253,7 @@ func (b *Core) isAllowed(ip netip.Addr, forceLive bool, method string) (bool, *m
 		return isAllowed, nil, errors.New("could not obtain netip.Addr from request") // fail closed
 	}
 
-	decision, err := b.retrieveDecision(ip, forceLive, method)
+	decision, err := b.retrieveDecision(ctx, ip, forceLive, method)
 	if err != nil {
 		return isAllowed, nil, err // fail closed
 	}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 
 	"github.com/hslatman/caddy-crowdsec-bouncer/internal/bouncer"
@@ -65,6 +66,7 @@ type Core struct {
 	userAgent           string
 	instantiatedAt      time.Time
 	instanceID          string
+	apiURL              string
 
 	ctx       context.Context
 	started   bool
@@ -76,7 +78,7 @@ type Core struct {
 }
 
 // New creates a new Bouncer with a storage based on immutable radix tree.
-func New(apiKey, apiURL, appSecURL string, appSecMaxBodySize int, appSecTimeout time.Duration, appSecFailOpen bool, tickerInterval string, logger *zap.Logger, caddyMetricsRegistry *prometheus.Registry, metricsInterval time.Duration) (*Core, error) {
+func New(apiKey, apiURL, appSecURL string, appSecMaxBodySize int, appSecTimeout time.Duration, appSecFailOpen bool, tickerInterval time.Duration, logger *zap.Logger, caddyMetricsRegistry *prometheus.Registry, metricsInterval time.Duration) (*Core, error) {
 	insecureSkipVerify := false
 	instantiatedAt := time.Now()
 	instanceID, err := generateInstanceID(instantiatedAt)
@@ -84,36 +86,38 @@ func New(apiKey, apiURL, appSecURL string, appSecMaxBodySize int, appSecTimeout 
 		return nil, fmt.Errorf("failed generating instance ID: %w", err)
 	}
 
+	apiClient, err := bouncer.NewAPIClient(apiURL, apiKey, userAgent, "", "", "", &insecureSkipVerify, log.StandardLogger())
+	if err != nil {
+		return nil, err
+	}
+
 	metricsRegistry := prometheus.NewRegistry()
-	metricsProvider, err := metrics.NewProvider(metricsRegistry, caddyMetricsRegistry, metricsInterval, logger, userAgentName, userAgentVersion, instanceID)
+	metricsProvider, err := metrics.NewProvider(apiClient, metricsRegistry, caddyMetricsRegistry, metricsInterval, logger, userAgentName, userAgentVersion, instanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	streamingBouncer, err := bouncer.NewStreamBouncer(apiClient, metricsProvider, tickerInterval, true)
+	if err != nil {
+		return nil, err
+	}
+
+	liveBouncer, err := bouncer.NewLiveBouncer(apiClient, metricsProvider)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Core{
-		streamingBouncer: &bouncer.StreamBouncer{ // TODO: refactor init
-			APIKey:              apiKey,
-			APIUrl:              apiURL,
-			InsecureSkipVerify:  &insecureSkipVerify,
-			TickerInterval:      tickerInterval,
-			UserAgent:           userAgent,
-			RetryInitialConnect: true,
-			MetricsProvider:     metricsProvider,
-		},
-		liveBouncer: &bouncer.LiveBouncer{ // TODO: refactor init
-			APIKey:             apiKey,
-			APIUrl:             apiURL,
-			InsecureSkipVerify: &insecureSkipVerify,
-			UserAgent:          userAgent,
-			MetricsProvider:    metricsProvider,
-		},
-		appsec:          newAppSec(appSecURL, apiKey, appSecMaxBodySize, appSecTimeout, appSecFailOpen, logger.Named("appsec"), metricsProvider), // TODO add fields here?
-		store:           newStore(),
-		metricsProvider: metricsProvider,
-		logger:          logger, // TODO add fields here?
-		userAgent:       userAgent,
-		instantiatedAt:  instantiatedAt,
-		instanceID:      instanceID,
+		apiURL:           apiURL,
+		streamingBouncer: streamingBouncer,
+		liveBouncer:      liveBouncer,
+		appsec:           newAppSec(appSecURL, apiKey, appSecMaxBodySize, appSecTimeout, appSecFailOpen, logger.Named("appsec"), metricsProvider), // TODO add fields here?
+		store:            newStore(),
+		metricsProvider:  metricsProvider,
+		logger:           logger, // TODO add fields here?
+		userAgent:        userAgent,
+		instantiatedAt:   instantiatedAt,
+		instanceID:       instanceID,
 	}, nil
 }
 
@@ -154,22 +158,10 @@ func (b *Core) Init() (err error) {
 	// live bouncer is also initialized for ad hoc live lookups.
 	if b.useStreamingBouncer {
 		b.logger.Info("initializing streaming bouncer", b.zapField())
-		if err = b.streamingBouncer.Init(); err != nil {
-			return err
-		}
-
 		b.logger.Info("initializing live bouncer for ad hoc live lookups", b.zapField())
-		if err = b.liveBouncer.Init(); err != nil {
-			return err
-		}
 	} else {
 		b.logger.Info("initializing live bouncer", b.zapField())
-		if err = b.liveBouncer.Init(); err != nil {
-			return err
-		}
 	}
-
-	b.metricsProvider.SetAPIClient(b.liveBouncer.APIClient) // TODO: refactor API client init
 
 	b.logAppSecStatus()
 

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -103,11 +103,7 @@ func New(apiKey, apiURL string, streamingEnabled bool, appSecURL string, appSecM
 		return nil, err
 	}
 
-	liveBouncer, err := bouncer.NewLiveBouncer(apiClient, metricsProvider)
-	if err != nil {
-		return nil, err
-	}
-
+	liveBouncer := bouncer.NewLiveBouncer(apiClient, metricsProvider)
 	appsec := newAppSec(appSecURL, apiKey, appSecMaxBodySize, appSecTimeout, appSecFailOpen, logger.Named("appsec"), metricsProvider)
 	store := newStore()
 
@@ -214,9 +210,7 @@ func (b *Core) Shutdown() error {
 	b.wg.Wait()
 
 	// TODO: clean shutdown of the streaming bouncer channel writing/reading?
-
-	b.logger.Warn("setting store nil") // TODO: remove
-	b.store = nil
+	//b.store = nil // TODO(hs): setting this to nil without reinstantiating it, leads to errors; do this properly.
 
 	b.stopped = true
 	b.logger.Info("finished shutdown", b.zapField())

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -78,7 +78,7 @@ type Core struct {
 }
 
 // New creates a new Bouncer with a storage based on immutable radix tree.
-func New(apiKey, apiURL, appSecURL string, appSecMaxBodySize int, appSecTimeout time.Duration, appSecFailOpen bool, tickerInterval time.Duration, logger *zap.Logger, caddyMetricsRegistry *prometheus.Registry, metricsInterval time.Duration) (*Core, error) {
+func New(apiKey, apiURL string, streamingEnabled bool, appSecURL string, appSecMaxBodySize int, appSecTimeout time.Duration, appSecFailOpen bool, tickerInterval time.Duration, shouldFailHard bool, logger *zap.Logger, caddyMetricsRegistry *prometheus.Registry, metricsInterval time.Duration) (*Core, error) {
 	insecureSkipVerify := false
 	instantiatedAt := time.Now()
 	instanceID, err := generateInstanceID(instantiatedAt)
@@ -97,7 +97,8 @@ func New(apiKey, apiURL, appSecURL string, appSecMaxBodySize int, appSecTimeout 
 		return nil, err
 	}
 
-	streamingBouncer, err := bouncer.NewStreamBouncer(apiClient, metricsProvider, tickerInterval, true)
+	retryInitialConnect := !shouldFailHard
+	streamingBouncer, err := bouncer.NewStreamBouncer(apiClient, metricsProvider, tickerInterval, retryInitialConnect)
 	if err != nil {
 		return nil, err
 	}
@@ -107,30 +108,23 @@ func New(apiKey, apiURL, appSecURL string, appSecMaxBodySize int, appSecTimeout 
 		return nil, err
 	}
 
+	appsec := newAppSec(appSecURL, apiKey, appSecMaxBodySize, appSecTimeout, appSecFailOpen, logger.Named("appsec"), metricsProvider)
+	store := newStore()
+
 	return &Core{
-		apiURL:           apiURL,
-		streamingBouncer: streamingBouncer,
-		liveBouncer:      liveBouncer,
-		appsec:           newAppSec(appSecURL, apiKey, appSecMaxBodySize, appSecTimeout, appSecFailOpen, logger.Named("appsec"), metricsProvider), // TODO add fields here?
-		store:            newStore(),
-		metricsProvider:  metricsProvider,
-		logger:           logger, // TODO add fields here?
-		userAgent:        userAgent,
-		instantiatedAt:   instantiatedAt,
-		instanceID:       instanceID,
+		apiURL:              apiURL,
+		streamingBouncer:    streamingBouncer,
+		useStreamingBouncer: streamingEnabled,
+		liveBouncer:         liveBouncer,
+		appsec:              appsec,
+		store:               store,
+		metricsProvider:     metricsProvider,
+		logger:              logger, // TODO add fields here?
+		shouldFailHard:      shouldFailHard,
+		userAgent:           userAgent,
+		instantiatedAt:      instantiatedAt,
+		instanceID:          instanceID,
 	}, nil
-}
-
-// EnableStreaming enables usage of the StreamBouncer (instead of the LiveBouncer).
-func (b *Core) EnableStreaming() {
-	b.useStreamingBouncer = true
-}
-
-// EnableHardFails will make the bouncer fail hard on (connection) errors
-// when contacting the CrowdSec Local API.
-func (b *Core) EnableHardFails() {
-	b.shouldFailHard = true
-	b.streamingBouncer.RetryInitialConnect = false
 }
 
 func (b *Core) NumberOfActiveDecisions() int {

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -145,7 +145,8 @@ func TestStreamingBouncer(t *testing.T) {
 	// run the bouncer; makes it make a call to the mocked CrowdSec API
 	// this should be called after the httpmock is activated, because otherwise the bouncer
 	// will try to call an actual CrowdSec instance
-	b.Run(t.Context())
+	ctx := t.Context()
+	b.Run(ctx)
 
 	// allow the bouncer a bit of time to retrieve and store the mocked rules
 	time.Sleep(1 * time.Second)
@@ -221,7 +222,7 @@ func TestStreamingBouncer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got, _, err := b.IsAllowed(tt.args.ip, forceLive, "")
+		got, _, err := b.IsAllowed(ctx, tt.args.ip, forceLive, "")
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. b.IsAllowed() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -24,14 +24,15 @@ func newCore(t *testing.T) (*Core, error) {
 
 	key := "apiKey"
 	host := "http://127.0.0.1:8080/"
+	streamingEnabled := true
 	tickerInterval := 10 * time.Second
 	logger := zaptest.NewLogger(t)
-
 	appSecTimeout := 2 * time.Second
-	bouncer, err := New(key, host, "", 0, appSecTimeout, false, tickerInterval, logger, nil, 0)
-	require.NoError(t, err)
+	appSecFailOpen := false
+	shouldFailHard := false
 
-	bouncer.EnableStreaming()
+	bouncer, err := New(key, host, streamingEnabled, "", 0, appSecTimeout, appSecFailOpen, tickerInterval, shouldFailHard, logger, nil, 0)
+	require.NoError(t, err)
 
 	// the code below mimicks the bouncer.streamingBouncer.Init() functionality
 	bouncer.streamingBouncer.Stream = make(chan *models.DecisionsStreamResponse)

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"net/netip"
 	"net/url"
 	"regexp"
@@ -23,7 +24,7 @@ func newCore(t *testing.T) (*Core, error) {
 
 	key := "apiKey"
 	host := "http://127.0.0.1:8080/"
-	tickerInterval := "10s"
+	tickerInterval := 10 * time.Second
 	logger := zaptest.NewLogger(t)
 
 	appSecTimeout := 2 * time.Second
@@ -35,11 +36,11 @@ func newCore(t *testing.T) (*Core, error) {
 	// the code below mimicks the bouncer.streamingBouncer.Init() functionality
 	bouncer.streamingBouncer.Stream = make(chan *models.DecisionsStreamResponse)
 
-	apiURL, err := url.Parse(bouncer.streamingBouncer.APIUrl)
-	require.NoError(t, err, "local API Url %q", bouncer.streamingBouncer.APIUrl)
+	apiURL, err := url.Parse(host)
+	require.NoError(t, err, "local API Url %q", host)
 
 	transport := &apiclient.APIKeyTransport{
-		APIKey:    bouncer.streamingBouncer.APIKey,
+		APIKey:    key,
 		Transport: httpmock.DefaultTransport, // crucial for httpmock to work correctly
 	}
 
@@ -47,15 +48,13 @@ func newCore(t *testing.T) (*Core, error) {
 	// the httpmock transport isn't, resulting in a panic. We've worked around this by specifying the
 	// Transport in the APIKeyTransport and waiting a bit before the bouncer is ran. This results in
 	// the goal of ensuring the bouncer gets mocked decisions.
-	bouncer.streamingBouncer.APIClient, err = apiclient.NewDefaultClient(apiURL, "v1", bouncer.streamingBouncer.UserAgent, transport.Client())
+	apiClient, err := apiclient.NewDefaultClient(apiURL, "v1", fmt.Sprintf("%s-testing", userAgent), transport.Client())
 	require.NoError(t, err)
-
-	bouncer.streamingBouncer.TickerIntervalDuration, err = time.ParseDuration(bouncer.streamingBouncer.TickerInterval)
-	require.NoError(t, err)
+	bouncer.streamingBouncer.SetAPIClientForTesting(apiClient)
 
 	metricsRegistry := prometheus.NewRegistry()
 	fakeCaddyMetricsRegistry := prometheus.NewRegistry()
-	bouncer.metricsProvider, err = metrics.NewProvider(metricsRegistry, fakeCaddyMetricsRegistry, 0, bouncer.logger, bouncer.instanceID, userAgentName, userAgentVersion)
+	bouncer.metricsProvider, err = metrics.NewProvider(apiClient, metricsRegistry, fakeCaddyMetricsRegistry, 0, bouncer.logger, bouncer.instanceID, userAgentName, userAgentVersion)
 
 	// initialization of the bouncer finished; running is responsibility of the caller
 

--- a/internal/core/decisions.go
+++ b/internal/core/decisions.go
@@ -27,7 +27,8 @@ func (b *Core) startProcessingDecisions(ctx context.Context) {
 				b.logger.Info("processing new and deleted decisions stopped", b.zapField())
 				return
 			case decisions := <-b.streamingBouncer.Stream:
-				if decisions == nil {
+				if decisions == nil { // TODO: remove this case when nil is never sent?
+					b.logger.Warn("hit decision nil")
 					continue
 				}
 				// TODO: deletions seem to include all old decisions that had already expired; CrowdSec bug or intended behavior?
@@ -101,12 +102,12 @@ func (b *Core) delete(decision *models.Decision) error {
 	return b.store.delete(decision)
 }
 
-func (b *Core) retrieveDecision(ip netip.Addr, forceLive bool, method string) (*models.Decision, error) {
+func (b *Core) retrieveDecision(ctx context.Context, ip netip.Addr, forceLive bool, method string) (*models.Decision, error) {
 	if b.useStreamingBouncer && !forceLive {
 		return b.store.get(ip)
 	}
 
-	decisions, err := b.liveBouncer.Get(ip.String(), method)
+	decisions, err := b.liveBouncer.Get(ctx, ip.String(), method)
 	if err != nil {
 		fields := []zapcore.Field{
 			b.zapField(),

--- a/internal/core/decisions.go
+++ b/internal/core/decisions.go
@@ -28,7 +28,6 @@ func (b *Core) startProcessingDecisions(ctx context.Context) {
 				return
 			case decisions := <-b.streamingBouncer.Stream:
 				if decisions == nil { // TODO: remove this case when nil is never sent?
-					b.logger.Warn("hit decision nil")
 					continue
 				}
 				// TODO: deletions seem to include all old decisions that had already expired; CrowdSec bug or intended behavior?

--- a/internal/core/decisions.go
+++ b/internal/core/decisions.go
@@ -111,7 +111,7 @@ func (b *Core) retrieveDecision(ctx context.Context, ip netip.Addr, forceLive bo
 	if err != nil {
 		fields := []zapcore.Field{
 			b.zapField(),
-			zap.String("address", b.liveBouncer.APIUrl),
+			zap.String("address", b.apiURL),
 			zap.Error(err),
 		}
 

--- a/internal/core/health.go
+++ b/internal/core/health.go
@@ -16,7 +16,7 @@ func (b *Core) Healthy(ctx context.Context) (bool, error) {
 // realistically should never be blocked. A successful response thus indicates
 // that a connection could be made.
 func (b *Core) Ping(ctx context.Context) (bool, error) {
-	if _, err := b.liveBouncer.Get("127.0.0.255", "ping"); err != nil { // TODO: pass type of request for metrics
+	if _, err := b.liveBouncer.Get(ctx, "127.0.0.255", "ping"); err != nil { // TODO: pass type of request for metrics
 		return false, fmt.Errorf("failed reaching CrowdSec LAPI: %w", err) // TODO: distinguish specific types of errors
 	}
 

--- a/internal/core/health.go
+++ b/internal/core/health.go
@@ -16,7 +16,7 @@ func (b *Core) Healthy(ctx context.Context) (bool, error) {
 // realistically should never be blocked. A successful response thus indicates
 // that a connection could be made.
 func (b *Core) Ping(ctx context.Context) (bool, error) {
-	if _, err := b.liveBouncer.Get(ctx, "127.0.0.255", "ping"); err != nil { // TODO: pass type of request for metrics
+	if _, err := b.liveBouncer.Get(ctx, "127.0.0.255", "ping"); err != nil {
 		return false, fmt.Errorf("failed reaching CrowdSec LAPI: %w", err) // TODO: distinguish specific types of errors
 	}
 

--- a/internal/core/logging.go
+++ b/internal/core/logging.go
@@ -31,7 +31,7 @@ func (b *Core) overrideLogrusLogger() {
 	hooks.Add(&zapAdapterHook{
 		logger:         b.logger,
 		shouldFailHard: b.shouldFailHard,
-		address:        b.streamingBouncer.APIUrl,
+		address:        b.apiURL,
 		instanceID:     b.instanceID,
 	})
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -69,7 +69,7 @@ func (m metricMap) registerAll(registry *prometheus.Registry) error {
 	return nil
 }
 
-func NewProvider(metricsRegistry, caddyMetricsRegistry *prometheus.Registry, interval time.Duration, logger *zap.Logger, userAgentName, userAgentVersion, instanceID string) (*Provider, error) {
+func NewProvider(apiClient *apiclient.ApiClient, metricsRegistry, caddyMetricsRegistry *prometheus.Registry, interval time.Duration, logger *zap.Logger, userAgentName, userAgentVersion, instanceID string) (*Provider, error) {
 	// bouncer metrics; provided by the go-cs-bouncer package, but overridden
 	// by recreating the main bouncer logic.
 	totalBouncerCallsCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -201,6 +201,7 @@ func NewProvider(metricsRegistry, caddyMetricsRegistry *prometheus.Registry, int
 	_ = osFamily
 
 	m := &Provider{
+		apiClient:                         apiClient,
 		interval:                          interval,
 		metricMap:                         metricMap,
 		metricsRegistry:                   metricsRegistry,
@@ -225,10 +226,6 @@ func NewProvider(metricsRegistry, caddyMetricsRegistry *prometheus.Registry, int
 	}
 
 	return m, nil
-}
-
-func (p *Provider) SetAPIClient(a *apiclient.ApiClient) {
-	p.apiClient = a
 }
 
 type Provider struct {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	modulePath = "github.com/hslatman/caddy-crowdsec-bouncer"
-	fallback   = "v0.8.0"
+	fallback   = "v0.14.0"
 )
 
 func Current() string {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -9,5 +9,5 @@ import (
 func TestCurrent(t *testing.T) {
 	v := Current()
 
-	assert.Equal(t, "v0.8.0", v) // fallback
+	assert.Equal(t, "v0.14.0", v) // fallback
 }

--- a/layer4/l4.go
+++ b/layer4/l4.go
@@ -81,7 +81,7 @@ func (m Matcher) Match(cx *l4.Connection) (bool, error) {
 
 	cx.Context = m.crowdsec.IncrementProcessedRequests(cx.Context, server, module, clientIP.Is6())
 
-	isAllowed, decision, err := m.crowdsec.IsAllowed(clientIP)
+	isAllowed, decision, err := m.crowdsec.IsAllowed(cx.Context, clientIP)
 	if err != nil {
 		return false, err
 	}
@@ -100,7 +100,7 @@ func (m *Matcher) Cleanup() error {
 		return nil
 	}
 
-	_ = m.logger.Sync() // nolint
+	_ = m.logger.Sync()
 
 	return nil
 }

--- a/test/live_test.go
+++ b/test/live_test.go
@@ -36,7 +36,7 @@ func TestLiveBouncer(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// simulate a lookup; no decisions available, so will be allowed
-	allowed, decision, err := crowdsec.IsAllowed(netip.MustParseAddr("127.0.0.1"))
+	allowed, decision, err := crowdsec.IsAllowed(ctx, netip.MustParseAddr("127.0.0.1"))
 	assert.NoError(t, err)
 	assert.True(t, allowed)
 	assert.Nil(t, decision)
@@ -48,7 +48,7 @@ func TestLiveBouncer(t *testing.T) {
 	testutils.LogContainerOutput(t, reader)
 
 	// simulate a lookup; 127.0.0.1 should now be banned
-	allowed, decision, err = crowdsec.IsAllowed(netip.MustParseAddr("127.0.0.1"))
+	allowed, decision, err = crowdsec.IsAllowed(ctx, netip.MustParseAddr("127.0.0.1"))
 	assert.NoError(t, err)
 	assert.False(t, allowed)
 	if assert.NotNil(t, decision) {

--- a/test/stream_test.go
+++ b/test/stream_test.go
@@ -33,7 +33,7 @@ func TestStreamingBouncer(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// simulate a lookup; no decisions available, so will be allowed
-	allowed, decision, err := crowdsec.IsAllowed(netip.MustParseAddr("127.0.0.1"))
+	allowed, decision, err := crowdsec.IsAllowed(ctx, netip.MustParseAddr("127.0.0.1"))
 	assert.NoError(t, err)
 	assert.True(t, allowed)
 	assert.Nil(t, decision)
@@ -48,7 +48,7 @@ func TestStreamingBouncer(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// simulate a lookup; 127.0.0.1 should now be banned
-	allowed, decision, err = crowdsec.IsAllowed(netip.MustParseAddr("127.0.0.1"))
+	allowed, decision, err = crowdsec.IsAllowed(ctx, netip.MustParseAddr("127.0.0.1"))
 	assert.NoError(t, err)
 	assert.False(t, allowed)
 	if assert.NotNil(t, decision) {


### PR DESCRIPTION
This PR cleans up some of the original CrowdSec library code that was ported over. The main improvements are a better initialization pattern, and feeding through `context.Context` when requests are made to the CrowdSec LAPI.