### PR TITLE
Make decision-stream sends cancellable

### DIFF
--- a/internal/bouncer/stream.go
+++ b/internal/bouncer/stream.go
@@ -79,7 +79,14 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 			return
 		}
 
-		b.Stream <- data
+		// Guard the send: on shutdown the consumer (Core.startProcessingDecisions)
+		// returns on ctx.Done(), so an unguarded send here would block forever and
+		// deadlock Core.Shutdown's wg.Wait().
+		select {
+		case b.Stream <- data:
+		case <-ctx.Done():
+			return
+		}
 		break
 	}
 
@@ -100,7 +107,13 @@ func (b *StreamBouncer) Run(ctx context.Context) {
 				log.Error(err)
 				continue
 			}
-			b.Stream <- data
+			// Guard the send so a shutdown mid-loop can't block on a consumer
+			// that has already returned on ctx.Done().
+			select {
+			case b.Stream <- data:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
▎ Authorship note: This change and its analysis were produced by Claude and verified on a real cluster by the submitter. Posting it as a human; please review on its merits.

Builds on streaming-bouncer-cleanup (thanks for the ctx-plumbing work — it fixes the dominant hang). This PR closes a remaining narrow race.

Problem: StreamBouncer.Run sends decisions on b.Stream with an unguarded send. On shutdown the consumer (Core.startProcessingDecisions) returns on <-ctx.Done(), so a send that races with cancellation blocks forever on a channel nobody reads → Core.Shutdown's b.wg.Wait() never returns. Under Caddy, Shutdown() runs inside changeConfig while the config write-lock is held, so this hangs the admin API and any config reload (relates to #61).

Fix: wrap both b.Stream <- data sends in a select on ctx.Done().

Verification: built a Caddy image with this branch + the streaming bouncer pointed at a live LAPI, then issued 4 config reloads (each a real changeConfig → old crowdsec app Stop()):
- crowdsec started×5 / stopping×4, 0 admin shutdown timeouts
- 0 goroutines blocked in Core.Shutdown
- exactly 1 StreamBouncer.Run alive afterward (no per-reload leak)
- GET /config/ responsive (<1 ms) after every reload

Without ctx-aware sends, a cancel during the send window would still wedge Shutdown.

(Minor: noticed leftover debug logging on this branch — log.Warn("running defer; closing stream?") in stream.go and logger.Warn("setting store nil") in core.go — left untouched as they look like your WIP markers.)