### PR TITLE
Preserve decision groups and remediation priority

### DIFF
--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -127,6 +127,44 @@ func decisions() *models.DecisionsStreamResponse {
 	}
 }
 
+func TestProcessNewDecisionsUsesOneReceivedAtPerBatch(t *testing.T) {
+	base := time.Date(2026, time.August, 14, 12, 0, 0, 0, time.UTC)
+	ip := netip.MustParseAddr("192.0.2.10")
+	lowerID := testDecision(10, "Ip", ip.String(), "captcha")
+	higherID := testDecision(11, "Range", "192.0.2.10/32", "captcha")
+
+	for _, test := range []struct {
+		name      string
+		decisions []*models.Decision
+	}{
+		{name: "forward", decisions: []*models.Decision{lowerID, higherID}},
+		{name: "reverse", decisions: []*models.Decision{higherID, lowerID}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clockCalls := 0
+			store := newStoreWithClock(func() time.Time {
+				current := base.Add(time.Duration(clockCalls) * 2 * time.Second)
+				clockCalls++
+				return current
+			})
+			bouncer := &Core{store: store, logger: zaptest.NewLogger(t)}
+
+			require.True(t, bouncer.processNewDecisions(test.decisions))
+			require.Equal(t, 1, clockCalls, "one stream response must use one clock reading")
+
+			bucket := store.store.buckets[netip.MustParsePrefix("192.0.2.10/32")]
+			require.Equal(t,
+				bucket.decisions[keyForDecision(lowerID)].expires,
+				bucket.decisions[keyForDecision(higherID)].expires,
+			)
+
+			selected, err := store.get(ip)
+			require.NoError(t, err)
+			requireDecisionIdentity(t, lowerID, selected, "batch order must not affect equal-lifetime selection")
+		})
+	}
+}
+
 func TestStreamingBouncer(t *testing.T) {
 	b, err := newCore(t)
 	require.NoError(t, err)

--- a/internal/core/decisions.go
+++ b/internal/core/decisions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"go.uber.org/zap"
@@ -64,21 +65,7 @@ func (b *Core) startProcessingDecisions(ctx context.Context) {
 
 				// TODO: process in separate goroutines/waitgroup?
 				// TODO: emit a Caddy event at the end of processing (new) decisions?
-				if numberOfNewDecisions := len(decisions.New); numberOfNewDecisions > 0 {
-					b.logger.Debug(fmt.Sprintf("processing %d new decisions", numberOfNewDecisions), b.zapField())
-					for _, decision := range decisions.New {
-						if err := b.add(decision); err != nil {
-							b.logger.Error(fmt.Sprintf("unable to insert decision for %q: %s", decisionValue(decision), err), b.zapField())
-						} else {
-							if numberOfNewDecisions <= maxNumberOfDecisionsToLog {
-								b.logger.Debug(fmt.Sprintf("adding %q (scope: %s) for %q", decisionValue(decision), decisionScope(decision), decisionDuration(decision)), b.zapField())
-							}
-						}
-					}
-					if numberOfNewDecisions > maxNumberOfDecisionsToLog {
-						b.logger.Debug(fmt.Sprintf("skipped logging for %d new decisions", numberOfNewDecisions), b.zapField())
-					}
-					b.logger.Debug(fmt.Sprintf("finished processing %d new decisions", numberOfNewDecisions), b.zapField())
+				if b.processNewDecisions(decisions.New) {
 					mustRecalculateDecisionCounts = true
 				}
 
@@ -93,9 +80,31 @@ func (b *Core) startProcessingDecisions(ctx context.Context) {
 	})
 }
 
-// add adds a Decision to the storage
-func (b *Core) add(decision *models.Decision) error {
+func (b *Core) processNewDecisions(decisions []*models.Decision) bool {
+	numberOfNewDecisions := len(decisions)
+	if numberOfNewDecisions == 0 {
+		return false
+	}
 
+	b.logger.Debug(fmt.Sprintf("processing %d new decisions", numberOfNewDecisions), b.zapField())
+	receivedAt := b.store.now()
+	for _, decision := range decisions {
+		if err := b.add(decision, receivedAt); err != nil {
+			b.logger.Error(fmt.Sprintf("unable to insert decision for %q: %s", decisionValue(decision), err), b.zapField())
+		} else if numberOfNewDecisions <= maxNumberOfDecisionsToLog {
+			b.logger.Debug(fmt.Sprintf("adding %q (scope: %s) for %q", decisionValue(decision), decisionScope(decision), decisionDuration(decision)), b.zapField())
+		}
+	}
+	if numberOfNewDecisions > maxNumberOfDecisionsToLog {
+		b.logger.Debug(fmt.Sprintf("skipped logging for %d new decisions", numberOfNewDecisions), b.zapField())
+	}
+	b.logger.Debug(fmt.Sprintf("finished processing %d new decisions", numberOfNewDecisions), b.zapField())
+
+	return true
+}
+
+// add adds a Decision to the storage
+func (b *Core) add(decision *models.Decision, receivedAt time.Time) error {
 	// TODO: provide additional ways for storing the decisions
 	// (i.e. radix tree is not always the most efficient one, but it's great for matching IPs to ranges)
 	// Knowing that a key is a CIDR does allow to check an IP with the .Contains() function, but still
@@ -104,7 +113,7 @@ func (b *Core) add(decision *models.Decision) error {
 	// TODO: store additional data about the decision (i.e. time added to store, etc)
 	// TODO: wrap the *models.Decision in an internal model (after validation)?
 
-	return b.store.add(decision)
+	return b.store.addAt(decision, receivedAt)
 }
 
 // delete removes a Decision from the storage

--- a/internal/core/decisions.go
+++ b/internal/core/decisions.go
@@ -26,21 +26,32 @@ func (b *Core) startProcessingDecisions(ctx context.Context) {
 			case <-ctx.Done():
 				b.logger.Info("processing new and deleted decisions stopped", b.zapField())
 				return
-			case decisions := <-b.streamingBouncer.Stream:
-				if decisions == nil { // TODO: remove this case when nil is never sent?
+			case decisions, ok := <-b.streamingBouncer.Stream:
+				if !ok {
+					b.logger.Info("decision stream closed", b.zapField())
+					return
+				}
+				if decisions == nil {
 					continue
 				}
-				// TODO: deletions seem to include all old decisions that had already expired; CrowdSec bug or intended behavior?
-				// TODO: process in separate goroutines/waitgroup?
 				mustRecalculateDecisionCounts := false
+				if pruned, err := b.store.pruneExpired(); err != nil {
+					b.logger.Error("unable to prune expired decisions", b.zapField(), zap.Error(err))
+				} else if pruned > 0 {
+					mustRecalculateDecisionCounts = true
+				}
+
+				// Startup streams intentionally include old expired decisions as
+				// tombstones. Deletion is idempotent, so process them normally.
+				// TODO: process in separate goroutines/waitgroup?
 				if numberOfDeletedDecisions := len(decisions.Deleted); numberOfDeletedDecisions > 0 {
 					b.logger.Debug(fmt.Sprintf("processing %d deleted decisions", numberOfDeletedDecisions), b.zapField())
 					for _, decision := range decisions.Deleted {
 						if err := b.delete(decision); err != nil {
-							b.logger.Error(fmt.Sprintf("unable to delete decision for %q: %s", *decision.Value, err), b.zapField())
+							b.logger.Error(fmt.Sprintf("unable to delete decision for %q: %s", decisionValue(decision), err), b.zapField())
 						} else {
 							if numberOfDeletedDecisions <= maxNumberOfDecisionsToLog {
-								b.logger.Debug(fmt.Sprintf("deleted %q (scope: %s)", *decision.Value, *decision.Scope), b.zapField())
+								b.logger.Debug(fmt.Sprintf("deleted %q (scope: %s)", decisionValue(decision), decisionScope(decision)), b.zapField())
 							}
 						}
 					}
@@ -57,10 +68,10 @@ func (b *Core) startProcessingDecisions(ctx context.Context) {
 					b.logger.Debug(fmt.Sprintf("processing %d new decisions", numberOfNewDecisions), b.zapField())
 					for _, decision := range decisions.New {
 						if err := b.add(decision); err != nil {
-							b.logger.Error(fmt.Sprintf("unable to insert decision for %q: %s", *decision.Value, err), b.zapField())
+							b.logger.Error(fmt.Sprintf("unable to insert decision for %q: %s", decisionValue(decision), err), b.zapField())
 						} else {
 							if numberOfNewDecisions <= maxNumberOfDecisionsToLog {
-								b.logger.Debug(fmt.Sprintf("adding %q (scope: %s) for %q", *decision.Value, *decision.Scope, *decision.Duration), b.zapField())
+								b.logger.Debug(fmt.Sprintf("adding %q (scope: %s) for %q", decisionValue(decision), decisionScope(decision), decisionDuration(decision)), b.zapField())
 							}
 						}
 					}
@@ -71,8 +82,8 @@ func (b *Core) startProcessingDecisions(ctx context.Context) {
 					mustRecalculateDecisionCounts = true
 				}
 
-				if mustRecalculateDecisionCounts {
-					b.metricsProvider.RecalculateAndRecordDecisionCounts(b.store.store)
+				if mustRecalculateDecisionCounts && b.metricsProvider.UsageMetricsEnabled() {
+					b.metricsProvider.RecalculateAndRecordDecisionCounts(b.store.metricsStore())
 				}
 
 				// send the (initial) metrics (once)
@@ -123,9 +134,33 @@ func (b *Core) retrieveDecision(ctx context.Context, ip netip.Addr, forceLive bo
 		return nil, nil // when not failing hard, we return no error
 	}
 
-	if len(*decisions) >= 1 {
-		return (*decisions)[0], nil // TODO: decide if choosing the first decision is OK
+	if decisions == nil {
+		return nil, nil
 	}
 
-	return nil, nil
+	return selectDecision(ip, []*models.Decision(*decisions))
+}
+
+func decisionValue(decision *models.Decision) string {
+	if decision == nil || decision.Value == nil {
+		return ""
+	}
+
+	return *decision.Value
+}
+
+func decisionScope(decision *models.Decision) string {
+	if decision == nil || decision.Scope == nil {
+		return ""
+	}
+
+	return *decision.Scope
+}
+
+func decisionDuration(decision *models.Decision) string {
+	if decision == nil || decision.Duration == nil {
+		return ""
+	}
+
+	return *decision.Duration
 }

--- a/internal/core/decisions.go
+++ b/internal/core/decisions.go
@@ -83,7 +83,7 @@ func (b *Core) startProcessingDecisions(ctx context.Context) {
 				}
 
 				if mustRecalculateDecisionCounts && b.metricsProvider.UsageMetricsEnabled() {
-					b.metricsProvider.RecalculateAndRecordDecisionCounts(b.store.metricsStore())
+					b.metricsProvider.RecalculateAndRecordDecisionCounts(b.store.activeDecisionSnapshot())
 				}
 
 				// send the (initial) metrics (once)

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"net/netip"
@@ -480,7 +481,7 @@ func candidatePrecedes(a, b *decisionCandidate) bool {
 		return a.decision.ID < b.decision.ID
 	}
 
-	return stableDecisionKey(a.decision) < stableDecisionKey(b.decision)
+	return compareDecisionTieBreak(a.decision, b.decision) < 0
 }
 
 func groupCandidatePrecedes(a, b *decisionCandidate) bool {
@@ -493,7 +494,7 @@ func groupCandidatePrecedes(a, b *decisionCandidate) bool {
 		// members can both be emitted and the stream upsert ends on the larger ID.
 		return a.decision.ID > b.decision.ID
 	}
-	return stableDecisionKey(a.decision) < stableDecisionKey(b.decision)
+	return compareDecisionTieBreak(a.decision, b.decision) < 0
 }
 
 // compareCandidateLifetime returns 1 when a outlives b, -1 when b outlives a,
@@ -575,7 +576,9 @@ func hasExpiredReportedDuration(decision *models.Decision) bool {
 }
 
 func remediationPriority(typ string) int {
-	switch strings.ToLower(strings.TrimSpace(typ)) {
+	// Keep the recognized wire values aligned with response handling. Any
+	// other spelling is a custom action and retains the fail-closed priority.
+	switch typ {
 	case "captcha":
 		return 2
 	case "throttle":
@@ -589,16 +592,65 @@ func remediationPriority(typ string) int {
 	}
 }
 
-func stableDecisionKey(decision *models.Decision) string {
-	return strings.Join([]string{
-		strings.ToLower(strings.TrimSpace(stringValue(decision.Type))),
-		strings.ToLower(strings.TrimSpace(stringValue(decision.Scope))),
-		strings.TrimSpace(stringValue(decision.Value)),
-		strings.TrimSpace(stringValue(decision.Origin)),
-		strings.TrimSpace(stringValue(decision.Scenario)),
-		strings.TrimSpace(stringValue(decision.Duration)),
-		decision.UUID,
-	}, "\x00")
+func compareDecisionTieBreak(a, b *models.Decision) int {
+	// Semantic groups use exact LAPI keys. Compare the raw fields here too, so
+	// distinct groups cannot collapse into a map-order-dependent tie.
+	if comparison := compareOptionalString(a.Type, b.Type); comparison != 0 {
+		return comparison
+	}
+	if comparison := compareOptionalString(a.Scope, b.Scope); comparison != 0 {
+		return comparison
+	}
+	if comparison := compareOptionalString(a.Value, b.Value); comparison != 0 {
+		return comparison
+	}
+	if comparison := compareOptionalString(a.Origin, b.Origin); comparison != 0 {
+		return comparison
+	}
+	if comparison := compareOptionalString(a.Scenario, b.Scenario); comparison != 0 {
+		return comparison
+	}
+	if comparison := compareOptionalString(a.Duration, b.Duration); comparison != 0 {
+		return comparison
+	}
+	if comparison := cmp.Compare(a.UUID, b.UUID); comparison != 0 {
+		return comparison
+	}
+	if comparison := cmp.Compare(a.Until, b.Until); comparison != 0 {
+		return comparison
+	}
+
+	return compareOptionalBool(a.Simulated, b.Simulated)
+}
+
+func compareOptionalString(a, b *string) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	default:
+		return cmp.Compare(*a, *b)
+	}
+}
+
+func compareOptionalBool(a, b *bool) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	case *a == *b:
+		return 0
+	case !*a:
+		return -1
+	default:
+		return 1
+	}
 }
 
 func keyForDecision(decision *models.Decision) decisionKey {

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/hslatman/ipstore"
+
+	"github.com/hslatman/caddy-crowdsec-bouncer/internal/metrics"
 )
 
 const (
@@ -297,48 +299,29 @@ func (s *decisionStore) Len() int {
 	return s.count
 }
 
-// metricsStore adapts the multi-value store to the metrics provider's current
-// single-value ipstore API. Synthetic keys are safe here: that provider only
-// inspects the address family and decision origin.
-func (s *store) metricsStore() *ipstore.Store[*models.Decision] {
-	return s.store.metricsStore()
+// activeDecisionSnapshot copies only the labels required by the metrics
+// provider. Expiration maintenance runs in the same stream batch before this
+// snapshot; the active check also prevents clock movement between those
+// operations from inflating the gauge.
+func (s *store) activeDecisionSnapshot() []metrics.ActiveDecision {
+	return s.store.activeDecisionSnapshot()
 }
 
-func (s *decisionStore) metricsStore() *ipstore.Store[*models.Decision] {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	_, _ = s.pruneExpiredLocked(s.now())
+func (s *decisionStore) activeDecisionSnapshot() []metrics.ActiveDecision {
+	now := s.now()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	result := ipstore.New[*models.Decision]()
-	var ipv4Index uint32
-	var ipv6Index uint64
-
+	result := make([]metrics.ActiveDecision, 0, s.count)
 	for prefix, bucket := range s.buckets {
 		for _, stored := range bucket.decisions {
-			metricDecision := decisionForMetrics(stored.decision)
-			if prefix.Addr().Is4() {
-				addr := netip.AddrFrom4([4]byte{
-					byte(ipv4Index >> 24),
-					byte(ipv4Index >> 16),
-					byte(ipv4Index >> 8),
-					byte(ipv4Index),
-				})
-				_ = result.Add(addr, metricDecision)
-				ipv4Index++
+			if !stored.expires.IsZero() && !stored.expires.After(now) {
 				continue
 			}
-
-			var raw [16]byte
-			raw[8] = byte(ipv6Index >> 56)
-			raw[9] = byte(ipv6Index >> 48)
-			raw[10] = byte(ipv6Index >> 40)
-			raw[11] = byte(ipv6Index >> 32)
-			raw[12] = byte(ipv6Index >> 24)
-			raw[13] = byte(ipv6Index >> 16)
-			raw[14] = byte(ipv6Index >> 8)
-			raw[15] = byte(ipv6Index)
-			_ = result.Add(netip.AddrFrom16(raw), metricDecision)
-			ipv6Index++
+			result = append(result, metrics.ActiveDecision{
+				Origin: stringValue(stored.decision.Origin),
+				IPv6:   prefix.Addr().Is6(),
+			})
 		}
 	}
 
@@ -682,16 +665,4 @@ func stringValue(value *string) string {
 	}
 
 	return *value
-}
-
-func decisionForMetrics(decision *models.Decision) *models.Decision {
-	if nonEmpty(decision.Origin) {
-		return decision
-	}
-
-	clone := *decision
-	origin := "unknown"
-	clone.Origin = &origin
-
-	return &clone
 }

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -15,137 +15,587 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/hslatman/ipstore"
 )
 
+// store retains the historical store.store access used by Core while allowing
+// more than one decision to exist at an exact IP or prefix.
 type store struct {
-	store *ipstore.Store[*models.Decision]
+	store *decisionStore
+}
+
+type decisionStore struct {
+	mu       sync.RWMutex
+	prefixes *ipstore.Store[*decisionBucket]
+	buckets  map[netip.Prefix]*decisionBucket
+	byID     map[int64]decisionLocation
+	count    int
+	now      func() time.Time
+}
+
+type decisionBucket struct {
+	decisions map[decisionKey]*storedDecision
+}
+
+// decisionKey mirrors the semantic key used by LAPI's default decision stream.
+// LAPI emits only the longest-lived decision for an exact scope/type/value
+// tuple, so additions replace that tuple and tombstones remove it regardless
+// of which effective decision ID was most recently observed.
+type decisionKey struct {
+	scope string
+	typ   string
+	value string
+}
+
+type decisionLocation struct {
+	prefix netip.Prefix
+	key    decisionKey
+}
+
+type storedDecision struct {
+	decision *models.Decision
+	expires  time.Time
+}
+
+type decisionCandidate struct {
+	decision *models.Decision
+	prefix   netip.Prefix
 }
 
 func newStore() *store {
+	return newStoreWithClock(time.Now)
+}
+
+func newStoreWithClock(now func() time.Time) *store {
+	if now == nil {
+		now = time.Now
+	}
+
 	return &store{
-		store: ipstore.New[*models.Decision](),
+		store: &decisionStore{
+			prefixes: ipstore.New[*decisionBucket](),
+			buckets:  make(map[netip.Prefix]*decisionBucket),
+			byID:     make(map[int64]decisionLocation),
+			now:      now,
+		},
 	}
 }
 
 func (s *store) add(decision *models.Decision) error {
-	if isInvalid(decision) {
-		return nil
+	if err := validateStoredDecision(decision); err != nil {
+		return err
 	}
 
-	scope := *decision.Scope
-	value := *decision.Value
-
-	switch scope {
-	case "Ip":
-		ip, err := parseIP(value)
-		if err != nil {
-			return err
-		}
-		return s.store.Add(ip, decision)
-	case "Range":
-		prf, err := netip.ParsePrefix(value)
-		if err != nil {
-			return err
-		}
-		return s.store.AddCIDR(prf, decision)
-	default:
-		return fmt.Errorf("got unhandled scope: %s", scope)
+	prefix, err := decisionPrefix(decision)
+	if err != nil {
+		return err
 	}
+
+	return s.store.add(prefix, decision)
+}
+
+func (s *decisionStore) add(prefix netip.Prefix, decision *models.Decision) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := keyForDecision(decision)
+	location := decisionLocation{prefix: prefix, key: key}
+
+	// A repeated ID is an update. Remove its previous representation first,
+	// including when the decision moved to a different target.
+	if decision.ID != 0 {
+		if oldLocation, ok := s.byID[decision.ID]; ok && oldLocation != location {
+			if err := s.removeByKeyLocked(oldLocation.prefix, oldLocation.key); err != nil {
+				return err
+			}
+		}
+	}
+
+	bucket, ok := s.buckets[prefix]
+	if !ok {
+		bucket = &decisionBucket{
+			decisions: make(map[decisionKey]*storedDecision),
+		}
+		if err := s.prefixes.AddCIDR(prefix, bucket); err != nil {
+			return err
+		}
+		s.buckets[prefix] = bucket
+	}
+
+	if previous, exists := bucket.decisions[key]; exists {
+		if previous.decision.ID != 0 {
+			delete(s.byID, previous.decision.ID)
+		}
+	} else {
+		s.count++
+	}
+	bucket.decisions[key] = &storedDecision{
+		decision: decision,
+		expires:  decisionExpiration(decision, s.now()),
+	}
+
+	if decision.ID != 0 {
+		s.byID[decision.ID] = location
+	}
+
+	return nil
 }
 
 func (s *store) delete(decision *models.Decision) error {
-	if isInvalid(decision) {
+	if decision == nil {
+		return errors.New("decision is nil")
+	}
+	if decision.ID < 0 {
+		return fmt.Errorf("decision ID must not be negative: %d", decision.ID)
+	}
+
+	// Stream tombstones carry the semantic target. Remove that effective key,
+	// even when its ID differs from the last addition: default LAPI streaming
+	// suppresses tombstones while another member of the tuple remains active.
+	if nonEmpty(decision.Scope) || nonEmpty(decision.Value) || nonEmpty(decision.Type) {
+		if err := validateStoredDecision(decision); err != nil {
+			return err
+		}
+		prefix, err := decisionPrefix(decision)
+		if err != nil {
+			return err
+		}
+		return s.store.deleteByKey(prefix, keyForDecision(decision))
+	}
+
+	if decision.ID != 0 {
+		return s.store.deleteByID(decision.ID)
+	}
+
+	return errors.New("decision deletion requires an ID or semantic target")
+}
+
+func (s *decisionStore) deleteByID(id int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	location, ok := s.byID[id]
+	if !ok {
 		return nil
 	}
 
-	scope := *decision.Scope
-	value := *decision.Value
+	return s.removeByKeyLocked(location.prefix, location.key)
+}
 
-	switch scope {
-	case "Ip":
-		ip, err := parseIP(value)
-		if err != nil {
-			return err
-		}
-		_, err = s.store.Remove(ip)
-		return err
-	case "Range":
-		prf, err := netip.ParsePrefix(value)
-		if err != nil {
-			return err
-		}
-		_, err = s.store.RemoveCIDR(prf)
-		return err
-	default:
-		return fmt.Errorf("got unhandled scope: %s", scope)
+func (s *decisionStore) deleteByKey(prefix netip.Prefix, key decisionKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.removeByKeyLocked(prefix, key)
+}
+
+func (s *decisionStore) removeByKeyLocked(prefix netip.Prefix, key decisionKey) error {
+	bucket, ok := s.buckets[prefix]
+	if !ok {
+		return nil
 	}
+
+	stored, ok := bucket.decisions[key]
+	if !ok {
+		return nil
+	}
+
+	delete(bucket.decisions, key)
+	if stored.decision.ID != 0 {
+		delete(s.byID, stored.decision.ID)
+	}
+	s.count--
+
+	if len(bucket.decisions) == 0 {
+		_, err := s.prefixes.RemoveCIDR(prefix)
+		if err == nil {
+			delete(s.buckets, prefix)
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (s *store) get(key netip.Addr) (*models.Decision, error) {
-	r, err := s.store.Get(key)
+	if !key.IsValid() {
+		return nil, errors.New("lookup address is invalid")
+	}
+
+	decisions, err := s.store.get(key)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(r) == 0 {
-		return nil, nil
-	}
-
-	// currently we return the first match, but the IP can exist in multiple
-	// networks (CIDR ranges) and there may thus be multiple Decisions to act
-	// upon. In general, though, the existence of at least a single Decision
-	// means that the IP should not be allowed, so it's relatively safe to use
-	// the first, but there may be 'softer' Decisions that should actually take
-	// precedence.
-
-	return r[0], err
+	return selectDecision(key, decisions)
 }
 
-// parseIP parses a value
-func parseIP(value string) (netip.Addr, error) {
-	var err error
-	var ip netip.Addr
-	ip, err = netip.ParseAddr(value)
-	if err != nil || !ip.IsValid() {
-		// try parsing as CIDR instead as fallback
-		prf, err := netip.ParsePrefix(value)
-		if err != nil {
-			return netip.Addr{}, err
+func (s *decisionStore) get(key netip.Addr) ([]*models.Decision, error) {
+	// Request lookups must not run global expiration maintenance: production
+	// stores commonly contain tens of thousands of decisions. Expired matches
+	// are filtered below, while stream, count, and metrics paths reclaim them.
+	now := s.now()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	buckets, err := s.prefixes.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	decisions := make([]*models.Decision, 0, len(buckets))
+	for _, bucket := range buckets {
+		decisions = bucket.appendActive(decisions, now)
+	}
+
+	return decisions, nil
+}
+
+func (b *decisionBucket) appendActive(decisions []*models.Decision, now time.Time) []*models.Decision {
+	for _, stored := range b.decisions {
+		if !stored.expires.IsZero() && !stored.expires.After(now) {
+			continue
 		}
-		// expect all bits to be ones for an IP; otherwise this is probably a range
-		ones, bits := prf.Bits(), prf.Addr().BitLen()
-		if ones != bits {
+		decisions = append(decisions, stored.decision)
+	}
+
+	return decisions
+}
+
+// Len reports decisions, not occupied prefixes. This keeps
+// Core.NumberOfActiveDecisions meaningful when multiple decisions share a
+// target.
+func (s *decisionStore) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, _ = s.pruneExpiredLocked(s.now())
+
+	return s.count
+}
+
+// metricsStore adapts the multi-value store to the metrics provider's current
+// single-value ipstore API. Synthetic keys are safe here: that provider only
+// inspects the address family and decision origin.
+func (s *store) metricsStore() *ipstore.Store[*models.Decision] {
+	return s.store.metricsStore()
+}
+
+func (s *decisionStore) metricsStore() *ipstore.Store[*models.Decision] {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, _ = s.pruneExpiredLocked(s.now())
+
+	result := ipstore.New[*models.Decision]()
+	var ipv4Index uint32
+	var ipv6Index uint64
+
+	for prefix, bucket := range s.buckets {
+		for _, stored := range bucket.decisions {
+			metricDecision := decisionForMetrics(stored.decision)
+			if prefix.Addr().Is4() {
+				addr := netip.AddrFrom4([4]byte{
+					byte(ipv4Index >> 24),
+					byte(ipv4Index >> 16),
+					byte(ipv4Index >> 8),
+					byte(ipv4Index),
+				})
+				_ = result.Add(addr, metricDecision)
+				ipv4Index++
+				continue
+			}
+
+			var raw [16]byte
+			raw[8] = byte(ipv6Index >> 56)
+			raw[9] = byte(ipv6Index >> 48)
+			raw[10] = byte(ipv6Index >> 40)
+			raw[11] = byte(ipv6Index >> 32)
+			raw[12] = byte(ipv6Index >> 24)
+			raw[13] = byte(ipv6Index >> 16)
+			raw[14] = byte(ipv6Index >> 8)
+			raw[15] = byte(ipv6Index)
+			_ = result.Add(netip.AddrFrom16(raw), metricDecision)
+			ipv6Index++
+		}
+	}
+
+	return result
+}
+
+func (s *store) pruneExpired() (int, error) {
+	s.store.mu.Lock()
+	defer s.store.mu.Unlock()
+	return s.store.pruneExpiredLocked(s.store.now())
+}
+
+func (s *decisionStore) pruneExpiredLocked(now time.Time) (int, error) {
+	type expiredDecision struct {
+		prefix netip.Prefix
+		key    decisionKey
+	}
+
+	expired := make([]expiredDecision, 0)
+	for prefix, bucket := range s.buckets {
+		for key, stored := range bucket.decisions {
+			if !stored.expires.IsZero() && !stored.expires.After(now) {
+				expired = append(expired, expiredDecision{prefix: prefix, key: key})
+			}
+		}
+	}
+
+	for _, item := range expired {
+		if err := s.removeByKeyLocked(item.prefix, item.key); err != nil {
+			return 0, err
+		}
+	}
+
+	return len(expired), nil
+}
+
+func decisionExpiration(decision *models.Decision, receivedAt time.Time) time.Time {
+	if decision == nil || decision.Duration == nil {
+		return time.Time{}
+	}
+	duration, err := time.ParseDuration(strings.TrimSpace(*decision.Duration))
+	if err != nil || duration <= 0 {
+		// Malformed metadata must not silently turn a blocking decision into an
+		// allow. Keep it until LAPI sends a tombstone instead.
+		return time.Time{}
+	}
+	return receivedAt.Add(duration)
+}
+
+// selectDecision is shared by streaming and live lookups. Higher remediation
+// priority wins before prefix specificity; remaining ties use stable decision
+// metadata so API and map iteration order cannot change the result.
+func selectDecision(ip netip.Addr, decisions []*models.Decision) (*models.Decision, error) {
+	if !ip.IsValid() {
+		return nil, errors.New("lookup address is invalid")
+	}
+
+	groups := make(map[decisionKey]*decisionCandidate)
+	var firstInvalid error
+	for i, decision := range decisions {
+		if err := validateStoredDecision(decision); err != nil {
+			if firstInvalid == nil {
+				firstInvalid = fmt.Errorf("invalid decision at index %d: %w", i, err)
+			}
+			continue
+		}
+
+		prefix, err := decisionPrefix(decision)
+		if err != nil {
+			if firstInvalid == nil {
+				firstInvalid = fmt.Errorf("invalid decision at index %d: %w", i, err)
+			}
+			continue
+		}
+		if !prefix.Contains(ip) {
+			continue
+		}
+
+		candidate := &decisionCandidate{decision: decision, prefix: prefix}
+		group := keyForDecision(decision)
+		if current := groups[group]; current == nil || groupCandidatePrecedes(candidate, current) {
+			groups[group] = candidate
+		}
+	}
+
+	var selected *decisionCandidate
+	for _, candidate := range groups {
+		if selected == nil || candidatePrecedes(candidate, selected) {
+			selected = candidate
+		}
+	}
+
+	if selected != nil && (firstInvalid == nil || remediationPriority(*selected.decision.Type) == 3) {
+		return selected.decision, nil
+	}
+	if firstInvalid != nil {
+		return nil, firstInvalid
+	}
+
+	return nil, nil
+}
+
+func candidatePrecedes(a, b *decisionCandidate) bool {
+	aPriority := remediationPriority(*a.decision.Type)
+	bPriority := remediationPriority(*b.decision.Type)
+	if aPriority != bPriority {
+		return aPriority > bPriority
+	}
+
+	if a.prefix.Bits() != b.prefix.Bits() {
+		return a.prefix.Bits() > b.prefix.Bits()
+	}
+
+	if aDuration, aOK := parsedDecisionDuration(a.decision); aOK {
+		if bDuration, bOK := parsedDecisionDuration(b.decision); !bOK || aDuration != bDuration {
+			return !bOK || aDuration > bDuration
+		}
+	} else if _, bOK := parsedDecisionDuration(b.decision); bOK {
+		return false
+	}
+
+	if a.decision.ID != b.decision.ID {
+		return a.decision.ID < b.decision.ID
+	}
+
+	return stableDecisionKey(a.decision) < stableDecisionKey(b.decision)
+}
+
+func groupCandidatePrecedes(a, b *decisionCandidate) bool {
+	aDuration, aOK := parsedDecisionDuration(a.decision)
+	bDuration, bOK := parsedDecisionDuration(b.decision)
+	if aOK != bOK {
+		return aOK
+	}
+	if aOK && aDuration != bDuration {
+		return aDuration > bDuration
+	}
+	if a.decision.ID != b.decision.ID {
+		return a.decision.ID < b.decision.ID
+	}
+	return stableDecisionKey(a.decision) < stableDecisionKey(b.decision)
+}
+
+func parsedDecisionDuration(decision *models.Decision) (time.Duration, bool) {
+	if decision == nil || decision.Duration == nil {
+		return 0, false
+	}
+	duration, err := time.ParseDuration(strings.TrimSpace(*decision.Duration))
+	return duration, err == nil && duration > 0
+}
+
+func remediationPriority(typ string) int {
+	switch strings.ToLower(strings.TrimSpace(typ)) {
+	case "captcha":
+		return 2
+	case "throttle":
+		return 1
+	case "ban":
+		return 3
+	default:
+		// Existing response handling converts unknown actions to a ban. Keep
+		// the selector equally fail-closed.
+		return 3
+	}
+}
+
+func stableDecisionKey(decision *models.Decision) string {
+	return strings.Join([]string{
+		strings.ToLower(strings.TrimSpace(stringValue(decision.Type))),
+		strings.ToLower(strings.TrimSpace(stringValue(decision.Scope))),
+		strings.TrimSpace(stringValue(decision.Value)),
+		strings.TrimSpace(stringValue(decision.Origin)),
+		strings.TrimSpace(stringValue(decision.Scenario)),
+		strings.TrimSpace(stringValue(decision.Duration)),
+		decision.UUID,
+	}, "\x00")
+}
+
+func keyForDecision(decision *models.Decision) decisionKey {
+	return decisionKey{
+		scope: *decision.Scope,
+		typ:   *decision.Type,
+		value: *decision.Value,
+	}
+}
+
+func decisionPrefix(decision *models.Decision) (netip.Prefix, error) {
+	scope := strings.ToLower(strings.TrimSpace(*decision.Scope))
+	value := strings.TrimSpace(*decision.Value)
+
+	switch scope {
+	case "ip":
+		ip, err := parseIP(value)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		return ip.Prefix(ip.BitLen())
+	case "range":
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			return netip.Prefix{}, err
+		}
+		return prefix.Masked(), nil
+	default:
+		return netip.Prefix{}, fmt.Errorf("got unhandled scope: %s", *decision.Scope)
+	}
+}
+
+// parseIP parses a value and accepts host-length CIDR notation as a fallback.
+func parseIP(value string) (netip.Addr, error) {
+	ip, err := netip.ParseAddr(value)
+	if err != nil || !ip.IsValid() {
+		prefix, prefixErr := netip.ParsePrefix(value)
+		if prefixErr != nil {
+			return netip.Addr{}, prefixErr
+		}
+		// Expect all bits to be ones for an IP; otherwise this is a range.
+		if prefix.Bits() != prefix.Addr().BitLen() {
 			return netip.Addr{}, fmt.Errorf("%s seems to be a range instead of an IP", value)
 		}
-		ip = prf.Addr()
+		ip = prefix.Addr()
 	}
+
 	return ip, nil
 }
 
-// isInvalid determines if a *models.Decision struct is
-// valid, meaning that it's not pointing to nil and has a
-// Scope, Value and Type set, the minimum required to operate
-func isInvalid(d *models.Decision) bool {
-	if d == nil {
-		return true
+func validateStoredDecision(decision *models.Decision) error {
+	if err := validateDecisionTarget(decision); err != nil {
+		return err
+	}
+	if decision.ID < 0 {
+		return fmt.Errorf("decision ID must not be negative: %d", decision.ID)
+	}
+	if !nonEmpty(decision.Type) {
+		return errors.New("decision type is missing")
 	}
 
-	if d.Scope == nil {
-		return true
+	return nil
+}
+
+func validateDecisionTarget(decision *models.Decision) error {
+	if decision == nil {
+		return errors.New("decision is nil")
+	}
+	if !nonEmpty(decision.Scope) {
+		return errors.New("decision scope is missing")
+	}
+	if !nonEmpty(decision.Value) {
+		return errors.New("decision value is missing")
 	}
 
-	if d.Value == nil {
-		return true
+	return nil
+}
+
+func nonEmpty(value *string) bool {
+	return value != nil && strings.TrimSpace(*value) != ""
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
 	}
 
-	if d.Type == nil {
-		return true
+	return *value
+}
+
+func decisionForMetrics(decision *models.Decision) *models.Decision {
+	if nonEmpty(decision.Origin) {
+		return decision
 	}
 
-	return false
+	clone := *decision
+	origin := "unknown"
+	clone.Origin = &origin
+
+	return &clone
 }

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -101,6 +101,10 @@ func newStoreWithClock(now func() time.Time) *store {
 }
 
 func (s *store) add(decision *models.Decision) error {
+	return s.addAt(decision, s.now())
+}
+
+func (s *store) addAt(decision *models.Decision, receivedAt time.Time) error {
 	if err := validateStoredDecision(decision); err != nil {
 		return err
 	}
@@ -110,10 +114,14 @@ func (s *store) add(decision *models.Decision) error {
 		return err
 	}
 
-	return s.store.add(prefix, decision)
+	return s.store.add(prefix, decision, receivedAt)
 }
 
-func (s *decisionStore) add(prefix netip.Prefix, decision *models.Decision) error {
+func (s *store) now() time.Time {
+	return s.store.now()
+}
+
+func (s *decisionStore) add(prefix netip.Prefix, decision *models.Decision, receivedAt time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -150,7 +158,7 @@ func (s *decisionStore) add(prefix netip.Prefix, decision *models.Decision) erro
 	}
 	bucket.decisions[key] = &storedDecision{
 		decision: decision,
-		expires:  decisionExpiration(decision, s.now()),
+		expires:  decisionExpiration(decision, receivedAt),
 	}
 
 	if decision.ID != 0 {
@@ -363,15 +371,18 @@ func decisionExpiration(decision *models.Decision, receivedAt time.Time) time.Ti
 		return time.Time{}
 	}
 	duration, err := time.ParseDuration(strings.TrimSpace(*decision.Duration))
-	if err != nil || duration < 0 {
+	if err != nil {
 		// Malformed metadata must not silently turn a blocking decision into an
 		// allow. Keep it until LAPI sends a tombstone instead.
 		return time.Time{}
 	}
+	if duration < 0 {
+		return receivedAt.Add(duration)
+	}
 
 	// LAPI uses Round(time.Second), so a still-active decision can legitimately
-	// arrive as "0s", and any non-negative duration can have been rounded down
-	// by almost half a second. Keep enforcing through that uncertainty window.
+	// arrive as "0s", and a non-negative duration can have been rounded down by
+	// almost half a second. Keep enforcing through that uncertainty window.
 	return receivedAt.Add(duration).Add(lapiDurationRoundingTolerance)
 }
 
@@ -408,6 +419,9 @@ func selectDecisionCandidate(ip netip.Addr, candidates []*decisionCandidate) (*d
 			if firstInvalid == nil {
 				firstInvalid = fmt.Errorf("invalid decision at index %d: %w", i, err)
 			}
+			continue
+		}
+		if hasExpiredReportedDuration(decision) {
 			continue
 		}
 
@@ -550,6 +564,14 @@ func parsedDecisionDuration(decision *models.Decision) (time.Duration, bool) {
 	}
 	duration, err := time.ParseDuration(strings.TrimSpace(*decision.Duration))
 	return duration, err == nil && duration >= 0
+}
+
+func hasExpiredReportedDuration(decision *models.Decision) bool {
+	if decision == nil || decision.Duration == nil {
+		return false
+	}
+	duration, err := time.ParseDuration(strings.TrimSpace(*decision.Duration))
+	return err == nil && duration < 0
 }
 
 func remediationPriority(typ string) int {

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -68,6 +68,7 @@ type storedDecision struct {
 type decisionCandidate struct {
 	decision *models.Decision
 	prefix   netip.Prefix
+	expires  time.Time
 }
 
 func newStore() *store {
@@ -229,15 +230,20 @@ func (s *store) get(key netip.Addr) (*models.Decision, error) {
 		return nil, errors.New("lookup address is invalid")
 	}
 
-	decisions, err := s.store.get(key)
+	candidates, now, err := s.store.get(key)
 	if err != nil {
 		return nil, err
 	}
 
-	return selectDecision(key, decisions)
+	selected, err := selectDecisionCandidate(key, candidates)
+	if err != nil || selected == nil {
+		return nil, err
+	}
+
+	return decisionAt(selected, now), nil
 }
 
-func (s *decisionStore) get(key netip.Addr) ([]*models.Decision, error) {
+func (s *decisionStore) get(key netip.Addr) ([]*decisionCandidate, time.Time, error) {
 	// Request lookups must not run global expiration maintenance: production
 	// stores commonly contain tens of thousands of decisions. Expired matches
 	// are filtered below, while stream, count, and metrics paths reclaim them.
@@ -247,26 +253,29 @@ func (s *decisionStore) get(key netip.Addr) ([]*models.Decision, error) {
 
 	buckets, err := s.prefixes.Get(key)
 	if err != nil {
-		return nil, err
+		return nil, now, err
 	}
 
-	decisions := make([]*models.Decision, 0, len(buckets))
+	candidates := make([]*decisionCandidate, 0, len(buckets))
 	for _, bucket := range buckets {
-		decisions = bucket.appendActive(decisions, now)
+		candidates = bucket.appendActive(candidates, now)
 	}
 
-	return decisions, nil
+	return candidates, now, nil
 }
 
-func (b *decisionBucket) appendActive(decisions []*models.Decision, now time.Time) []*models.Decision {
+func (b *decisionBucket) appendActive(candidates []*decisionCandidate, now time.Time) []*decisionCandidate {
 	for _, stored := range b.decisions {
 		if !stored.expires.IsZero() && !stored.expires.After(now) {
 			continue
 		}
-		decisions = append(decisions, stored.decision)
+		candidates = append(candidates, &decisionCandidate{
+			decision: stored.decision,
+			expires:  stored.expires,
+		})
 	}
 
-	return decisions
+	return candidates
 }
 
 // Len reports decisions, not occupied prefixes. This keeps
@@ -375,13 +384,31 @@ func decisionExpiration(decision *models.Decision, receivedAt time.Time) time.Ti
 // priority wins before prefix specificity; remaining ties use stable decision
 // metadata so API and map iteration order cannot change the result.
 func selectDecision(ip netip.Addr, decisions []*models.Decision) (*models.Decision, error) {
+	candidates := make([]*decisionCandidate, 0, len(decisions))
+	for _, decision := range decisions {
+		candidates = append(candidates, &decisionCandidate{decision: decision})
+	}
+
+	selected, err := selectDecisionCandidate(ip, candidates)
+	if err != nil || selected == nil {
+		return nil, err
+	}
+
+	return selected.decision, nil
+}
+
+func selectDecisionCandidate(ip netip.Addr, candidates []*decisionCandidate) (*decisionCandidate, error) {
 	if !ip.IsValid() {
 		return nil, errors.New("lookup address is invalid")
 	}
 
 	groups := make(map[decisionKey]*decisionCandidate)
 	var firstInvalid error
-	for i, decision := range decisions {
+	for i, input := range candidates {
+		var decision *models.Decision
+		if input != nil {
+			decision = input.decision
+		}
 		if err := validateStoredDecision(decision); err != nil {
 			if firstInvalid == nil {
 				firstInvalid = fmt.Errorf("invalid decision at index %d: %w", i, err)
@@ -400,7 +427,8 @@ func selectDecision(ip netip.Addr, decisions []*models.Decision) (*models.Decisi
 			continue
 		}
 
-		candidate := &decisionCandidate{decision: decision, prefix: prefix}
+		candidate := input
+		candidate.prefix = prefix
 		group := keyForDecision(decision)
 		if current := groups[group]; current == nil || groupCandidatePrecedes(candidate, current) {
 			groups[group] = candidate
@@ -415,7 +443,7 @@ func selectDecision(ip netip.Addr, decisions []*models.Decision) (*models.Decisi
 	}
 
 	if selected != nil && (firstInvalid == nil || remediationPriority(*selected.decision.Type) == 3) {
-		return selected.decision, nil
+		return selected, nil
 	}
 	if firstInvalid != nil {
 		return nil, firstInvalid
@@ -435,12 +463,8 @@ func candidatePrecedes(a, b *decisionCandidate) bool {
 		return a.prefix.Bits() > b.prefix.Bits()
 	}
 
-	if aDuration, aOK := parsedDecisionDuration(a.decision); aOK {
-		if bDuration, bOK := parsedDecisionDuration(b.decision); !bOK || aDuration != bDuration {
-			return !bOK || aDuration > bDuration
-		}
-	} else if _, bOK := parsedDecisionDuration(b.decision); bOK {
-		return false
+	if lifetimeComparison := compareCandidateLifetime(a, b); lifetimeComparison != 0 {
+		return lifetimeComparison > 0
 	}
 
 	if a.decision.ID != b.decision.ID {
@@ -451,18 +475,72 @@ func candidatePrecedes(a, b *decisionCandidate) bool {
 }
 
 func groupCandidatePrecedes(a, b *decisionCandidate) bool {
-	aDuration, aOK := parsedDecisionDuration(a.decision)
-	bDuration, bOK := parsedDecisionDuration(b.decision)
-	if aOK != bOK {
-		return aOK
-	}
-	if aOK && aDuration != bDuration {
-		return aDuration > bDuration
+	if lifetimeComparison := compareCandidateLifetime(a, b); lifetimeComparison != 0 {
+		return lifetimeComparison > 0
 	}
 	if a.decision.ID != b.decision.ID {
-		return a.decision.ID < b.decision.ID
+		// LAPI orders stream results by ascending ID. Its longest-decision
+		// predicate uses a strict greater-than comparison, so equal-until group
+		// members can both be emitted and the stream upsert ends on the larger ID.
+		return a.decision.ID > b.decision.ID
 	}
 	return stableDecisionKey(a.decision) < stableDecisionKey(b.decision)
+}
+
+// compareCandidateLifetime returns 1 when a outlives b, -1 when b outlives a,
+// and 0 when their usable lifetime metadata is equal. Stored candidates carry
+// an absolute local expiry; live candidates carry LAPI's remaining Duration.
+func compareCandidateLifetime(a, b *decisionCandidate) int {
+	aExpiryValid := !a.expires.IsZero()
+	bExpiryValid := !b.expires.IsZero()
+	if aExpiryValid || bExpiryValid {
+		// LAPI serializes remaining duration at one-second precision. Ignore
+		// sub-second skew introduced while processing members of one response.
+		aExpiry := a.expires.Round(time.Second)
+		bExpiry := b.expires.Round(time.Second)
+		switch {
+		case aExpiryValid && !bExpiryValid:
+			return 1
+		case !aExpiryValid && bExpiryValid:
+			return -1
+		case aExpiry.After(bExpiry):
+			return 1
+		case aExpiry.Before(bExpiry):
+			return -1
+		default:
+			return 0
+		}
+	}
+
+	aDuration, aDurationValid := parsedDecisionDuration(a.decision)
+	bDuration, bDurationValid := parsedDecisionDuration(b.decision)
+	switch {
+	case aDurationValid && !bDurationValid:
+		return 1
+	case !aDurationValid && bDurationValid:
+		return -1
+	case aDuration > bDuration:
+		return 1
+	case aDuration < bDuration:
+		return -1
+	default:
+		return 0
+	}
+}
+
+func decisionAt(candidate *decisionCandidate, now time.Time) *models.Decision {
+	if candidate == nil || candidate.decision == nil || candidate.expires.IsZero() {
+		if candidate == nil {
+			return nil
+		}
+		return candidate.decision
+	}
+
+	clone := *candidate.decision
+	remaining := candidate.expires.Sub(now).Round(time.Second).String()
+	clone.Duration = &remaining
+
+	return &clone
 }
 
 func parsedDecisionDuration(decision *models.Decision) (time.Duration, bool) {

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -26,6 +26,14 @@ import (
 	"github.com/hslatman/ipstore"
 )
 
+const (
+	// LAPI serializes a decision's remaining lifetime after rounding it to the
+	// nearest second. Half of that unit is therefore the largest possible
+	// round-down error that the local store must cover.
+	lapiDurationRoundingUnit      = time.Second
+	lapiDurationRoundingTolerance = lapiDurationRoundingUnit / 2
+)
+
 // store retains the historical store.store access used by Core while allowing
 // more than one decision to exist at an exact IP or prefix.
 type store struct {
@@ -372,12 +380,16 @@ func decisionExpiration(decision *models.Decision, receivedAt time.Time) time.Ti
 		return time.Time{}
 	}
 	duration, err := time.ParseDuration(strings.TrimSpace(*decision.Duration))
-	if err != nil || duration <= 0 {
+	if err != nil || duration < 0 {
 		// Malformed metadata must not silently turn a blocking decision into an
 		// allow. Keep it until LAPI sends a tombstone instead.
 		return time.Time{}
 	}
-	return receivedAt.Add(duration)
+
+	// LAPI uses Round(time.Second), so a still-active decision can legitimately
+	// arrive as "0s", and any non-negative duration can have been rounded down
+	// by almost half a second. Keep enforcing through that uncertainty window.
+	return receivedAt.Add(duration).Add(lapiDurationRoundingTolerance)
 }
 
 // selectDecision is shared by streaming and live lookups. Higher remediation
@@ -537,7 +549,13 @@ func decisionAt(candidate *decisionCandidate, now time.Time) *models.Decision {
 	}
 
 	clone := *candidate.decision
-	remaining := candidate.expires.Sub(now).Round(time.Second).String()
+	// expires includes the fail-closed uncertainty window. Do not expose that
+	// implementation detail as extra LAPI lifetime to callers.
+	remainingDuration := candidate.expires.Add(-lapiDurationRoundingTolerance).Sub(now)
+	if remainingDuration < 0 {
+		remainingDuration = 0
+	}
+	remaining := remainingDuration.Round(lapiDurationRoundingUnit).String()
 	clone.Duration = &remaining
 
 	return &clone
@@ -548,7 +566,7 @@ func parsedDecisionDuration(decision *models.Decision) (time.Duration, bool) {
 		return 0, false
 	}
 	duration, err := time.ParseDuration(strings.TrimSpace(*decision.Duration))
-	return duration, err == nil && duration > 0
+	return duration, err == nil && duration >= 0
 }
 
 func remediationPriority(typ string) int {

--- a/internal/core/store_bench_test.go
+++ b/internal/core/store_bench_test.go
@@ -1,0 +1,121 @@
+// Copyright 2021 Herman Slatman
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+	"net/netip"
+	"testing"
+
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+)
+
+func BenchmarkStoreLookupByDecisionCount(b *testing.B) {
+	for _, decisionCount := range []int{1_000, 10_000, 100_000} {
+		decisionCount := decisionCount
+		b.Run(fmt.Sprintf("decisions_%d", decisionCount), func(b *testing.B) {
+			store := benchmarkStore(b, decisionCount)
+			hit := benchmarkIPv4(decisionCount - 1)
+			miss := netip.MustParseAddr("203.0.113.1")
+
+			b.Run("hit", func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					decision, err := store.get(hit)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if decision == nil {
+						b.Fatal("expected a matching decision")
+					}
+				}
+			})
+
+			b.Run("miss", func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					decision, err := store.get(miss)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if decision != nil {
+						b.Fatal("expected no matching decision")
+					}
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkStoreLookupParallel100K(b *testing.B) {
+	store := benchmarkStore(b, 100_000)
+	hit := benchmarkIPv4(99_999)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			decision, err := store.get(hit)
+			if err != nil {
+				b.Error(err)
+				return
+			}
+			if decision == nil {
+				b.Error("expected a matching decision")
+				return
+			}
+		}
+	})
+}
+
+func benchmarkStore(b *testing.B, decisionCount int) *store {
+	b.Helper()
+	b.StopTimer()
+
+	result := newStore()
+	for index := range decisionCount {
+		if err := result.add(benchmarkDecision(int64(index+1), benchmarkIPv4(index))); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.StartTimer()
+	return result
+}
+
+func benchmarkDecision(id int64, address netip.Addr) *models.Decision {
+	duration := "1h"
+	scope := "Ip"
+	typ := "ban"
+	value := address.String()
+
+	return &models.Decision{
+		Duration: &duration,
+		ID:       id,
+		Scope:    &scope,
+		Type:     &typ,
+		Value:    &value,
+	}
+}
+
+func benchmarkIPv4(index int) netip.Addr {
+	value := uint32(index)
+	return netip.AddrFrom4([4]byte{
+		10,
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	})
+}

--- a/internal/core/store_bench_test.go
+++ b/internal/core/store_bench_test.go
@@ -1,17 +1,3 @@
-// Copyright 2021 Herman Slatman
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package core
 
 import (

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -15,8 +15,12 @@
 package core
 
 import (
+	"fmt"
 	"net/netip"
+	"slices"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/stretchr/testify/require"
@@ -113,4 +117,501 @@ func TestStore(t *testing.T) {
 	r1, err = s.get(ip1)
 	require.NoError(t, err)
 	require.Nil(t, r1)
+}
+
+func TestStoreRetainsAndSelectsMultipleDecisionsForOneTarget(t *testing.T) {
+	tests := []struct {
+		name     string
+		types    []string
+		expected string
+	}{
+		{
+			name:     "ban takes precedence over captcha and throttle",
+			types:    []string{"throttle", "captcha", "ban"},
+			expected: "ban",
+		},
+		{
+			name:     "unknown action remains fail closed",
+			types:    []string{"captcha", "custom-remediation"},
+			expected: "custom-remediation",
+		},
+		{
+			name:     "captcha takes precedence over throttle",
+			types:    []string{"throttle", "captcha"},
+			expected: "captcha",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			orders := [][]string{test.types, slices.Clone(test.types)}
+			slices.Reverse(orders[1])
+
+			for _, order := range orders {
+				s := newStore()
+				for index, typ := range order {
+					require.NoError(t, s.add(testDecision(int64(index+1), "Ip", "192.0.2.10", typ)))
+				}
+
+				require.Equal(t, len(test.types), s.store.Len())
+				selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+				require.NoError(t, err)
+				require.NotNil(t, selected)
+				require.Equal(t, test.expected, *selected.Type)
+			}
+		})
+	}
+}
+
+func TestStoreSelectsAcrossOverlappingIPAndRanges(t *testing.T) {
+	s := newStore()
+	rangeCaptcha := testDecision(1, "Range", "192.0.2.99/24", "captcha")
+	ipThrottle := testDecision(2, "Ip", "192.0.2.10", "throttle")
+	rangeBan := testDecision(3, "Range", "192.0.0.0/16", "ban")
+	ipBan := testDecision(4, "Ip", "192.0.2.10", "ban")
+
+	for _, decision := range []*models.Decision{rangeCaptcha, ipThrottle, rangeBan, ipBan} {
+		require.NoError(t, s.add(decision))
+	}
+
+	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Same(t, ipBan, selected, "the more-specific decision should break equal-action ties")
+
+	require.NoError(t, s.delete(ipBan))
+	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Same(t, rangeBan, selected, "action priority should beat prefix specificity")
+
+	require.NoError(t, s.delete(rangeBan))
+	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Same(t, rangeCaptcha, selected, "captcha should beat a more-specific throttle")
+}
+
+func TestStoreKeepsOverlappingPrefixBucketsIndependent(t *testing.T) {
+	s := newStore()
+	rangeDecision := testDecision(1, "Range", "192.0.2.0/24", "captcha")
+	ipDecision := testDecision(2, "Ip", "192.0.2.10", "throttle")
+	require.NoError(t, s.add(rangeDecision))
+	require.NoError(t, s.add(ipDecision))
+
+	rangePrefix := netip.MustParsePrefix("192.0.2.0/24")
+	ipPrefix := netip.MustParsePrefix("192.0.2.10/32")
+	require.NotSame(t, s.store.buckets[rangePrefix], s.store.buckets[ipPrefix])
+	require.Equal(t, 2, s.metricsStore().Len(), "metrics must not duplicate decisions across overlapping prefixes")
+
+	require.NoError(t, s.delete(rangeDecision))
+	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Same(t, ipDecision, selected)
+	require.Equal(t, 1, s.metricsStore().Len())
+}
+
+func TestStoreDeleteUsesDecisionID(t *testing.T) {
+	t.Run("only matching ID is removed", func(t *testing.T) {
+		s := newStore()
+		captcha := testDecision(10, "Ip", "192.0.2.10", "captcha")
+		ban := testDecision(11, "Ip", "192.0.2.10", "ban")
+		require.NoError(t, s.add(captcha))
+		require.NoError(t, s.add(ban))
+
+		require.NoError(t, s.delete(&models.Decision{ID: captcha.ID}))
+		require.Equal(t, 1, s.store.Len())
+
+		selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+		require.NoError(t, err)
+		require.Same(t, ban, selected)
+	})
+
+	t.Run("complete tombstone removes the effective semantic group", func(t *testing.T) {
+		s := newStore()
+		stored := testDecision(10, "Ip", "192.0.2.10", "ban")
+		require.NoError(t, s.add(stored))
+
+		tombstone := testDecision(999, "Ip", "192.0.2.10", "ban")
+		require.NoError(t, s.delete(tombstone))
+		require.Zero(t, s.store.Len())
+	})
+
+	t.Run("same ID updates and can move target", func(t *testing.T) {
+		s := newStore()
+		original := testDecision(10, "Ip", "192.0.2.10", "captcha")
+		updated := testDecision(10, "Ip", "192.0.2.11", "ban")
+		require.NoError(t, s.add(original))
+		require.NoError(t, s.add(updated))
+		require.Equal(t, 1, s.store.Len())
+
+		selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+		require.NoError(t, err)
+		require.Nil(t, selected)
+
+		selected, err = s.get(netip.MustParseAddr("192.0.2.11"))
+		require.NoError(t, err)
+		require.Same(t, updated, selected)
+	})
+
+	t.Run("new LAPI decision supersedes the same target and remediation", func(t *testing.T) {
+		s := newStore()
+		oldCaptcha := testDecision(10, "Ip", "192.0.2.10", "captcha")
+		newCaptcha := testDecision(11, "Ip", "192.0.2.10", "captcha")
+		ban := testDecision(12, "Ip", "192.0.2.10", "ban")
+
+		require.NoError(t, s.add(oldCaptcha))
+		require.NoError(t, s.add(ban))
+		require.NoError(t, s.add(newCaptcha))
+		require.Equal(t, 2, s.store.Len(), "different remediation types must remain independent")
+
+		require.NoError(t, s.delete(&models.Decision{ID: oldCaptcha.ID}))
+		selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+		require.NoError(t, err)
+		require.Same(t, ban, selected, "a delayed tombstone for the superseded ID must be harmless")
+
+		require.NoError(t, s.delete(ban))
+		selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
+		require.NoError(t, err)
+		require.Same(t, newCaptcha, selected)
+
+		require.NoError(t, s.delete(newCaptcha))
+		require.Zero(t, s.store.Len())
+	})
+}
+
+func TestStoreDeleteWithoutID(t *testing.T) {
+	t.Run("unique semantic match", func(t *testing.T) {
+		s := newStore()
+		stored := testDecision(0, "Range", "192.0.2.99/24", "captcha")
+		require.NoError(t, s.add(stored))
+
+		tombstone := testDecision(0, "Range", "192.0.2.99/24", "captcha")
+		require.NoError(t, s.delete(tombstone))
+		require.Zero(t, s.store.Len())
+	})
+
+	t.Run("same stream group is upserted independent of origin", func(t *testing.T) {
+		s := newStore()
+		first := testDecision(0, "Ip", "192.0.2.10", "ban")
+		*first.Scenario = "first ID-less source"
+		second := testDecision(0, "Ip", "192.0.2.10", "ban")
+		*second.Origin = "CAPI"
+		*second.Scenario = "second ID-less source"
+		require.NoError(t, s.add(first))
+		require.NoError(t, s.add(second))
+		require.Equal(t, 1, s.store.Len())
+
+		tombstone := testDecision(0, "Ip", "192.0.2.10", "ban")
+		require.NoError(t, s.delete(tombstone))
+		require.Zero(t, s.store.Len())
+	})
+
+	t.Run("semantic tombstone preserves other remediation groups", func(t *testing.T) {
+		s := newStore()
+		ban := testDecision(0, "Ip", "192.0.2.10", "ban")
+		captcha := testDecision(3, "Ip", "192.0.2.10", "captcha")
+		require.NoError(t, s.add(ban))
+		require.NoError(t, s.add(captcha))
+
+		tombstone := testDecision(0, "ip", "192.0.2.10", "ban")
+		*tombstone.Scope = "Ip"
+		require.NoError(t, s.delete(tombstone))
+		require.Equal(t, 1, s.store.Len())
+
+		selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+		require.NoError(t, err)
+		require.Same(t, captcha, selected)
+	})
+}
+
+func TestSelectDecisionIsOrderIndependentForLiveResults(t *testing.T) {
+	ip := netip.MustParseAddr("192.0.2.10")
+	decisions := []*models.Decision{
+		testDecision(30, "Range", "192.0.2.0/24", "throttle"),
+		testDecision(20, "Range", "192.0.2.0/24", "captcha"),
+		testDecision(10, "Range", "192.0.0.0/16", "ban"),
+	}
+
+	selected, err := selectDecision(ip, decisions)
+	require.NoError(t, err)
+	require.EqualValues(t, 10, selected.ID)
+
+	slices.Reverse(decisions)
+	selected, err = selectDecision(ip, decisions)
+	require.NoError(t, err)
+	require.EqualValues(t, 10, selected.ID)
+
+	unrelated := testDecision(1, "Ip", "198.51.100.1", "ban")
+	selected, err = selectDecision(ip, []*models.Decision{unrelated})
+	require.NoError(t, err)
+	require.Nil(t, selected)
+}
+
+func TestSelectDecisionUsesLongestLiveDecisionWithinGroup(t *testing.T) {
+	ip := netip.MustParseAddr("192.0.2.10")
+	shorter := testDecision(1, "Ip", ip.String(), "captcha")
+	longer := testDecision(2, "Ip", ip.String(), "captcha")
+	*shorter.Duration = "1m"
+	*longer.Duration = "2m"
+
+	for _, decisions := range [][]*models.Decision{{shorter, longer}, {longer, shorter}} {
+		selected, err := selectDecision(ip, decisions)
+		require.NoError(t, err)
+		require.Same(t, longer, selected)
+	}
+}
+
+func TestStoreKeepsExactLAPIGroupKeysIndependent(t *testing.T) {
+	s := newStore()
+	plainIP := testDecision(1, "Ip", "192.0.2.10", "captcha")
+	cidrIP := testDecision(2, "Ip", "192.0.2.10/32", "captcha")
+	rangeIP := testDecision(3, "Range", "192.0.2.10/32", "captcha")
+	spacedIP := testDecision(4, "Ip", " 192.0.2.10 ", "captcha")
+	lowercaseScope := testDecision(5, "ip", "192.0.2.10", "captcha")
+	for _, decision := range []*models.Decision{plainIP, cidrIP, rangeIP, spacedIP, lowercaseScope} {
+		require.NoError(t, s.add(decision))
+	}
+	require.Equal(t, 5, s.store.Len())
+
+	require.NoError(t, s.delete(testDecision(99, "Ip", "192.0.2.10", "captcha")))
+	require.Equal(t, 4, s.store.Len())
+}
+
+func TestStoreLookupIgnoresExpiredDecisionsWithoutGlobalMaintenance(t *testing.T) {
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	s := newStoreWithClock(func() time.Time { return now })
+	expiredMatch := testDecision(1, "Ip", "192.0.2.10", "captcha")
+	*expiredMatch.Duration = time.Second.String()
+	activeMatch := testDecision(2, "Range", "192.0.2.0/24", "throttle")
+	*activeMatch.Duration = time.Minute.String()
+	expiredUnrelated := testDecision(3, "Ip", "198.51.100.10", "ban")
+	*expiredUnrelated.Duration = time.Second.String()
+
+	require.NoError(t, s.add(expiredMatch))
+	require.NoError(t, s.add(activeMatch))
+	require.NoError(t, s.add(expiredUnrelated))
+	require.Equal(t, 3, s.store.Len())
+
+	now = now.Add(time.Second)
+	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Same(t, activeMatch, selected, "an expired higher-priority action must not be enforced")
+	require.Equal(t, 3, s.store.count, "request lookup must not scan and mutate the whole store")
+
+	require.Equal(t, 1, s.store.Len(), "maintenance paths should physically remove expired decisions")
+	require.Equal(t, 1, s.metricsStore().Len())
+}
+
+func TestStoreKeepsMalformedDurationFailClosedUntilTombstone(t *testing.T) {
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	s := newStoreWithClock(func() time.Time { return now })
+	decision := testDecision(1, "Ip", "192.0.2.10", "ban")
+	*decision.Duration = "invalid"
+	require.NoError(t, s.add(decision))
+
+	now = now.Add(24 * time.Hour)
+	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Same(t, decision, selected)
+	require.NoError(t, s.delete(testDecision(2, "Ip", "192.0.2.10", "ban")))
+	require.Zero(t, s.store.Len())
+}
+
+func TestStoreRejectsMalformedDecisions(t *testing.T) {
+	valid := testDecision(1, "Ip", "192.0.2.10", "ban")
+
+	tests := []struct {
+		name     string
+		decision *models.Decision
+	}{
+		{name: "nil decision"},
+		{name: "empty decision", decision: &models.Decision{}},
+		{name: "missing scope", decision: cloneDecision(valid, func(d *models.Decision) { d.Scope = nil })},
+		{name: "missing value", decision: cloneDecision(valid, func(d *models.Decision) { d.Value = nil })},
+		{name: "missing type", decision: cloneDecision(valid, func(d *models.Decision) { d.Type = nil })},
+		{name: "negative ID", decision: cloneDecision(valid, func(d *models.Decision) { d.ID = -1 })},
+		{name: "unsupported scope", decision: testDecision(1, "Country", "US", "ban")},
+		{name: "invalid IP", decision: testDecision(1, "Ip", "not-an-ip", "ban")},
+		{name: "range in IP scope", decision: testDecision(1, "Ip", "192.0.2.0/24", "ban")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := newStore()
+			require.Error(t, s.add(test.decision))
+			require.Zero(t, s.store.Len())
+		})
+	}
+
+	_, err := selectDecision(netip.MustParseAddr("192.0.2.10"), []*models.Decision{nil})
+	require.Error(t, err)
+	_, err = newStore().get(netip.Addr{})
+	require.Error(t, err)
+}
+
+func TestStoreAcceptsOptionalDecisionMetadata(t *testing.T) {
+	s := newStore()
+	decision := testDecision(1, "Ip", "192.0.2.10", "ban")
+	decision.Duration = nil
+	decision.Origin = nil
+	decision.Scenario = nil
+
+	require.NoError(t, s.add(decision))
+	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Same(t, decision, selected)
+
+	metricsStore := s.metricsStore()
+	for _, metricDecision := range metricsStore.All() {
+		require.NotNil(t, metricDecision.Origin)
+		require.Equal(t, "unknown", *metricDecision.Origin)
+		require.Nil(t, decision.Origin, "metrics adaptation must not mutate the stored decision")
+	}
+}
+
+func TestSelectDecisionMalformedEntryCannotHideValidBan(t *testing.T) {
+	ip := netip.MustParseAddr("192.0.2.10")
+	validBan := testDecision(1, "Ip", ip.String(), "ban")
+	malformed := &models.Decision{}
+
+	selected, err := selectDecision(ip, []*models.Decision{malformed, validBan})
+	require.NoError(t, err)
+	require.Same(t, validBan, selected)
+
+	_, err = selectDecision(ip, []*models.Decision{malformed})
+	require.Error(t, err, "an entirely malformed response must not become an allow")
+}
+
+func TestMetricsStoreIncludesEveryDecisionAndAddressFamily(t *testing.T) {
+	s := newStore()
+	require.NoError(t, s.add(testDecision(1, "Ip", "192.0.2.10", "ban")))
+	require.NoError(t, s.add(testDecision(2, "Ip", "192.0.2.10", "captcha")))
+	require.NoError(t, s.add(testDecision(3, "Range", "2001:db8::/32", "ban")))
+
+	metricsStore := s.metricsStore()
+	require.Equal(t, 3, metricsStore.Len())
+
+	var ipv4, ipv6 int
+	for prefix := range metricsStore.All() {
+		if prefix.Addr().Is4() {
+			ipv4++
+		} else {
+			ipv6++
+		}
+	}
+	require.Equal(t, 2, ipv4)
+	require.Equal(t, 1, ipv6)
+}
+
+func TestStoreConcurrentAddLookupAndDelete(t *testing.T) {
+	const count = 64
+	s := newStore()
+	errs := make(chan error, count)
+
+	var wg sync.WaitGroup
+	for id := 1; id <= count; id++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- s.add(testDecision(int64(id), "Ip", "192.0.2.10", "captcha"))
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, s.store.Len(), "LAPI exposes one effective decision per target and remediation")
+
+	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.NotNil(t, selected)
+
+	errs = make(chan error, count)
+	for id := 1; id <= count; id++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- s.delete(&models.Decision{ID: int64(id)})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Zero(t, s.store.Len())
+}
+
+func TestStoreConcurrentLookupAndMaintenance(t *testing.T) {
+	const (
+		readers    = 32
+		iterations = 100
+	)
+
+	s := newStore()
+	expected := testDecision(1, "Range", "192.0.2.0/24", "ban")
+	require.NoError(t, s.add(expected))
+
+	errs := make(chan error, readers+1)
+	var wg sync.WaitGroup
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+				if err != nil {
+					errs <- err
+					return
+				}
+				if selected != expected {
+					errs <- fmt.Errorf("unexpected selected decision: %p", selected)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		decision := testDecision(2, "Ip", "198.51.100.10", "captcha")
+		for range iterations {
+			if err := s.add(decision); err != nil {
+				errs <- err
+				return
+			}
+			if err := s.delete(decision); err != nil {
+				errs <- err
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func testDecision(id int64, scope, value, typ string) *models.Decision {
+	duration := "120s"
+	origin := "cscli"
+	scenario := fmt.Sprintf("test scenario %s", typ)
+
+	return &models.Decision{
+		Duration: &duration,
+		ID:       id,
+		Origin:   &origin,
+		Scenario: &scenario,
+		Scope:    &scope,
+		Type:     &typ,
+		Value:    &value,
+	}
+}
+
+func cloneDecision(decision *models.Decision, mutate func(*models.Decision)) *models.Decision {
+	clone := *decision
+	mutate(&clone)
+	return &clone
 }

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -136,6 +136,16 @@ func TestStoreRetainsAndSelectsMultipleDecisionsForOneTarget(t *testing.T) {
 			expected: "custom-remediation",
 		},
 		{
+			name:     "uppercase throttle remains an unknown fail-closed action",
+			types:    []string{"captcha", "THROTTLE"},
+			expected: "THROTTLE",
+		},
+		{
+			name:     "spaced throttle remains an unknown fail-closed action",
+			types:    []string{"captcha", " throttle "},
+			expected: " throttle ",
+		},
+		{
 			name:     "captcha takes precedence over throttle",
 			types:    []string{"throttle", "captcha"},
 			expected: "captcha",
@@ -346,6 +356,33 @@ func TestSelectDecisionIsOrderIndependentForLiveResults(t *testing.T) {
 	selected, err = selectDecision(ip, []*models.Decision{unrelated})
 	require.NoError(t, err)
 	require.Nil(t, selected)
+}
+
+func TestSelectDecisionUsesExactWireValuesForStableTieBreak(t *testing.T) {
+	ip := netip.MustParseAddr("192.0.2.10")
+	uppercase := testDecision(0, "Ip", ip.String(), "CUSTOM")
+	lowercase := testDecision(0, "Ip", ip.String(), "custom")
+	*uppercase.Scenario = "same scenario"
+	*lowercase.Scenario = "same scenario"
+
+	require.Negative(t, compareDecisionTieBreak(uppercase, lowercase))
+	require.Positive(t, compareDecisionTieBreak(lowercase, uppercase))
+
+	for _, decisions := range [][]*models.Decision{{uppercase, lowercase}, {lowercase, uppercase}} {
+		selected, err := selectDecision(ip, decisions)
+		require.NoError(t, err)
+		require.Same(t, uppercase, selected)
+	}
+
+	nilOrigin := cloneDecision(uppercase, func(decision *models.Decision) {
+		decision.Origin = nil
+	})
+	emptyOrigin := cloneDecision(uppercase, func(decision *models.Decision) {
+		empty := ""
+		decision.Origin = &empty
+	})
+	require.Negative(t, compareDecisionTieBreak(nilOrigin, emptyOrigin))
+	require.Positive(t, compareDecisionTieBreak(emptyOrigin, nilOrigin))
 }
 
 func TestSelectDecisionUsesLongestLiveDecisionWithinGroup(t *testing.T) {

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -176,17 +176,17 @@ func TestStoreSelectsAcrossOverlappingIPAndRanges(t *testing.T) {
 
 	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
 	require.NoError(t, err)
-	require.Same(t, ipBan, selected, "the more-specific decision should break equal-action ties")
+	requireDecisionIdentity(t, ipBan, selected, "the more-specific decision should break equal-action ties")
 
 	require.NoError(t, s.delete(ipBan))
 	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
 	require.NoError(t, err)
-	require.Same(t, rangeBan, selected, "action priority should beat prefix specificity")
+	requireDecisionIdentity(t, rangeBan, selected, "action priority should beat prefix specificity")
 
 	require.NoError(t, s.delete(rangeBan))
 	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
 	require.NoError(t, err)
-	require.Same(t, rangeCaptcha, selected, "captcha should beat a more-specific throttle")
+	requireDecisionIdentity(t, rangeCaptcha, selected, "captcha should beat a more-specific throttle")
 }
 
 func TestStoreKeepsOverlappingPrefixBucketsIndependent(t *testing.T) {
@@ -204,7 +204,7 @@ func TestStoreKeepsOverlappingPrefixBucketsIndependent(t *testing.T) {
 	require.NoError(t, s.delete(rangeDecision))
 	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
 	require.NoError(t, err)
-	require.Same(t, ipDecision, selected)
+	requireDecisionIdentity(t, ipDecision, selected)
 	require.Equal(t, 1, s.metricsStore().Len())
 }
 
@@ -221,7 +221,7 @@ func TestStoreDeleteUsesDecisionID(t *testing.T) {
 
 		selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
 		require.NoError(t, err)
-		require.Same(t, ban, selected)
+		requireDecisionIdentity(t, ban, selected)
 	})
 
 	t.Run("complete tombstone removes the effective semantic group", func(t *testing.T) {
@@ -248,7 +248,7 @@ func TestStoreDeleteUsesDecisionID(t *testing.T) {
 
 		selected, err = s.get(netip.MustParseAddr("192.0.2.11"))
 		require.NoError(t, err)
-		require.Same(t, updated, selected)
+		requireDecisionIdentity(t, updated, selected)
 	})
 
 	t.Run("new LAPI decision supersedes the same target and remediation", func(t *testing.T) {
@@ -265,12 +265,12 @@ func TestStoreDeleteUsesDecisionID(t *testing.T) {
 		require.NoError(t, s.delete(&models.Decision{ID: oldCaptcha.ID}))
 		selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
 		require.NoError(t, err)
-		require.Same(t, ban, selected, "a delayed tombstone for the superseded ID must be harmless")
+		requireDecisionIdentity(t, ban, selected, "a delayed tombstone for the superseded ID must be harmless")
 
 		require.NoError(t, s.delete(ban))
 		selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
 		require.NoError(t, err)
-		require.Same(t, newCaptcha, selected)
+		requireDecisionIdentity(t, newCaptcha, selected)
 
 		require.NoError(t, s.delete(newCaptcha))
 		require.Zero(t, s.store.Len())
@@ -298,6 +298,11 @@ func TestStoreDeleteWithoutID(t *testing.T) {
 		require.NoError(t, s.add(first))
 		require.NoError(t, s.add(second))
 		require.Equal(t, 1, s.store.Len())
+		metricsStore := s.metricsStore()
+		require.Equal(t, 1, metricsStore.Len(), "metrics must count the effective group, not every historical member")
+		for _, metricDecision := range metricsStore.All() {
+			require.Equal(t, "CAPI", stringValue(metricDecision.Origin))
+		}
 
 		tombstone := testDecision(0, "Ip", "192.0.2.10", "ban")
 		require.NoError(t, s.delete(tombstone))
@@ -318,7 +323,7 @@ func TestStoreDeleteWithoutID(t *testing.T) {
 
 		selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
 		require.NoError(t, err)
-		require.Same(t, captcha, selected)
+		requireDecisionIdentity(t, captcha, selected)
 	})
 }
 
@@ -359,6 +364,75 @@ func TestSelectDecisionUsesLongestLiveDecisionWithinGroup(t *testing.T) {
 	}
 }
 
+func TestSelectDecisionMatchesStreamUpsertForEqualLongestGroupMembers(t *testing.T) {
+	ip := netip.MustParseAddr("192.0.2.10")
+	lowerID := testDecision(10, "Ip", ip.String(), "captcha")
+	higherID := testDecision(11, "Ip", ip.String(), "captcha")
+	*lowerID.Origin = "first"
+	*higherID.Origin = "second"
+
+	// LAPI's longest-decision predicate is strict. Members with the same Until
+	// can therefore both be returned by the stream, ordered by ascending ID;
+	// the semantic upsert ends on the higher ID.
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	stream := newStoreWithClock(func() time.Time { return now })
+	require.NoError(t, stream.add(lowerID))
+	require.NoError(t, stream.add(higherID))
+	streamSelected, err := stream.get(ip)
+	require.NoError(t, err)
+	requireDecisionIdentity(t, higherID, streamSelected)
+
+	for _, live := range [][]*models.Decision{{lowerID, higherID}, {higherID, lowerID}} {
+		liveSelected, err := selectDecision(ip, live)
+		require.NoError(t, err)
+		require.Same(t, higherID, liveSelected)
+		requireDecisionIdentity(t, streamSelected, liveSelected)
+	}
+}
+
+func TestLiveAndDefaultStreamSelectTheSameEffectiveDecision(t *testing.T) {
+	ip := netip.MustParseAddr("192.0.2.10")
+	shortCaptcha := testDecision(10, "Ip", ip.String(), "captcha")
+	longCaptcha := testDecision(11, "Ip", ip.String(), "captcha")
+	throttle := testDecision(12, "Range", "192.0.2.0/24", "throttle")
+	*shortCaptcha.Duration = "1m"
+	*longCaptcha.Duration = "2m"
+	*throttle.Duration = "3m"
+
+	liveSelected, err := selectDecision(ip, []*models.Decision{shortCaptcha, throttle, longCaptcha})
+	require.NoError(t, err)
+	require.Same(t, longCaptcha, liveSelected)
+
+	// The default stream emits only the longest member of an exact
+	// scope/type/value group.
+	stream := newStore()
+	require.NoError(t, stream.add(longCaptcha))
+	require.NoError(t, stream.add(throttle))
+	streamSelected, err := stream.get(ip)
+	require.NoError(t, err)
+	requireDecisionIdentity(t, liveSelected, streamSelected)
+}
+
+func TestLiveAndStreamIgnoreSubsecondIngestionSkew(t *testing.T) {
+	ip := netip.MustParseAddr("192.0.2.10")
+	lowerID := testDecision(10, "Ip", ip.String(), "captcha")
+	higherID := testDecision(11, "Range", "192.0.2.10/32", "captcha")
+
+	liveSelected, err := selectDecision(ip, []*models.Decision{higherID, lowerID})
+	require.NoError(t, err)
+	require.Same(t, lowerID, liveSelected)
+
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	stream := newStoreWithClock(func() time.Time { return now })
+	require.NoError(t, stream.add(lowerID))
+	now = now.Add(time.Millisecond)
+	require.NoError(t, stream.add(higherID))
+
+	streamSelected, err := stream.get(ip)
+	require.NoError(t, err)
+	requireDecisionIdentity(t, liveSelected, streamSelected)
+}
+
 func TestStoreKeepsExactLAPIGroupKeysIndependent(t *testing.T) {
 	s := newStore()
 	plainIP := testDecision(1, "Ip", "192.0.2.10", "captcha")
@@ -366,13 +440,14 @@ func TestStoreKeepsExactLAPIGroupKeysIndependent(t *testing.T) {
 	rangeIP := testDecision(3, "Range", "192.0.2.10/32", "captcha")
 	spacedIP := testDecision(4, "Ip", " 192.0.2.10 ", "captcha")
 	lowercaseScope := testDecision(5, "ip", "192.0.2.10", "captcha")
-	for _, decision := range []*models.Decision{plainIP, cidrIP, rangeIP, spacedIP, lowercaseScope} {
+	uppercaseType := testDecision(6, "Ip", "192.0.2.10", "CAPTCHA")
+	for _, decision := range []*models.Decision{plainIP, cidrIP, rangeIP, spacedIP, lowercaseScope, uppercaseType} {
 		require.NoError(t, s.add(decision))
 	}
-	require.Equal(t, 5, s.store.Len())
+	require.Equal(t, 6, s.store.Len())
 
 	require.NoError(t, s.delete(testDecision(99, "Ip", "192.0.2.10", "captcha")))
-	require.Equal(t, 4, s.store.Len())
+	require.Equal(t, 5, s.store.Len())
 }
 
 func TestStoreLookupIgnoresExpiredDecisionsWithoutGlobalMaintenance(t *testing.T) {
@@ -393,11 +468,33 @@ func TestStoreLookupIgnoresExpiredDecisionsWithoutGlobalMaintenance(t *testing.T
 	now = now.Add(time.Second)
 	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
 	require.NoError(t, err)
-	require.Same(t, activeMatch, selected, "an expired higher-priority action must not be enforced")
+	requireDecisionIdentity(t, activeMatch, selected, "an expired higher-priority action must not be enforced")
 	require.Equal(t, 3, s.store.count, "request lookup must not scan and mutate the whole store")
 
 	require.Equal(t, 1, s.store.Len(), "maintenance paths should physically remove expired decisions")
 	require.Equal(t, 1, s.metricsStore().Len())
+}
+
+func TestStoreReturnsRemainingDurationWithoutMutatingStreamDecision(t *testing.T) {
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	s := newStoreWithClock(func() time.Time { return now })
+	decision := testDecision(1, "Ip", "192.0.2.10", "throttle")
+	*decision.Duration = "2m"
+	require.NoError(t, s.add(decision))
+
+	now = now.Add(30 * time.Second)
+	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	requireDecisionIdentity(t, decision, selected)
+	require.Equal(t, "1m30s", stringValue(selected.Duration))
+	require.Equal(t, "2m", stringValue(decision.Duration), "lookup must not mutate a decision shared with the stream")
+
+	now = now.Add(90 * time.Second)
+	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Nil(t, selected)
+	require.Zero(t, s.store.Len())
+	require.Zero(t, s.metricsStore().Len())
 }
 
 func TestStoreKeepsMalformedDurationFailClosedUntilTombstone(t *testing.T) {
@@ -563,7 +660,7 @@ func TestStoreConcurrentLookupAndMaintenance(t *testing.T) {
 					errs <- err
 					return
 				}
-				if selected != expected {
+				if selected == nil || selected.ID != expected.ID {
 					errs <- fmt.Errorf("unexpected selected decision: %p", selected)
 					return
 				}
@@ -614,4 +711,15 @@ func cloneDecision(decision *models.Decision, mutate func(*models.Decision)) *mo
 	clone := *decision
 	mutate(&clone)
 	return &clone
+}
+
+func requireDecisionIdentity(t *testing.T, expected, actual *models.Decision, msgAndArgs ...any) {
+	t.Helper()
+	require.NotNil(t, actual, msgAndArgs...)
+	require.Equal(t, expected.ID, actual.ID, msgAndArgs...)
+	require.Equal(t, stringValue(expected.Scope), stringValue(actual.Scope), msgAndArgs...)
+	require.Equal(t, stringValue(expected.Type), stringValue(actual.Type), msgAndArgs...)
+	require.Equal(t, stringValue(expected.Value), stringValue(actual.Value), msgAndArgs...)
+	require.Equal(t, stringValue(expected.Origin), stringValue(actual.Origin), msgAndArgs...)
+	require.Equal(t, stringValue(expected.Scenario), stringValue(actual.Scenario), msgAndArgs...)
 }

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -502,6 +502,51 @@ func TestStoreZeroRoundedDurationExpiresAfterTolerance(t *testing.T) {
 	require.Zero(t, s.store.Len(), "a valid zero duration must never become an unbounded local decision")
 }
 
+func TestStoreNegativeDurationIsKnownExpired(t *testing.T) {
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	ip := netip.MustParseAddr("192.0.2.10")
+	prefix := netip.MustParsePrefix("192.0.2.10/32")
+
+	for _, duration := range []string{"-1s", "-2s"} {
+		t.Run(duration, func(t *testing.T) {
+			s := newStoreWithClock(func() time.Time { return now })
+			decision := testDecision(1, "Ip", ip.String(), "ban")
+			*decision.Duration = duration
+			require.NoError(t, s.add(decision))
+
+			stored := s.store.buckets[prefix].decisions[keyForDecision(decision)]
+			require.False(t, stored.expires.IsZero(), "a valid negative duration has a known expiry")
+			require.True(t, stored.expires.Before(now))
+
+			selected, err := s.get(ip)
+			require.NoError(t, err)
+			require.Nil(t, selected)
+			require.Zero(t, s.store.Len())
+		})
+	}
+}
+
+func TestSelectDecisionIgnoresExpiredLiveDuration(t *testing.T) {
+	ip := netip.MustParseAddr("192.0.2.10")
+	expiredBan := testDecision(1, "Ip", ip.String(), "ban")
+	*expiredBan.Duration = "-1s"
+	activeCaptcha := testDecision(2, "Ip", ip.String(), "captcha")
+	*activeCaptcha.Duration = "1m"
+
+	for _, decisions := range [][]*models.Decision{
+		{expiredBan, activeCaptcha},
+		{activeCaptcha, expiredBan},
+	} {
+		selected, err := selectDecision(ip, decisions)
+		require.NoError(t, err)
+		require.Same(t, activeCaptcha, selected)
+	}
+
+	selected, err := selectDecision(ip, []*models.Decision{expiredBan})
+	require.NoError(t, err)
+	require.Nil(t, selected)
+}
+
 func TestStoreReturnsRemainingDurationWithoutMutatingStreamDecision(t *testing.T) {
 	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
 	s := newStoreWithClock(func() time.Time { return now })
@@ -578,18 +623,12 @@ func TestStoreRejectsMalformedDecisions(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestStoreAcceptsOptionalDecisionMetadata(t *testing.T) {
+func TestActiveDecisionSnapshotHandlesMissingOriginWithoutMutation(t *testing.T) {
 	s := newStore()
 	decision := testDecision(1, "Ip", "192.0.2.10", "ban")
-	decision.Duration = nil
 	decision.Origin = nil
-	decision.Scenario = nil
 
 	require.NoError(t, s.add(decision))
-	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
-	require.NoError(t, err)
-	require.Same(t, decision, selected)
-
 	snapshot := s.activeDecisionSnapshot()
 	require.Len(t, snapshot, 1)
 	require.Empty(t, snapshot[0].Origin)

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -199,13 +199,13 @@ func TestStoreKeepsOverlappingPrefixBucketsIndependent(t *testing.T) {
 	rangePrefix := netip.MustParsePrefix("192.0.2.0/24")
 	ipPrefix := netip.MustParsePrefix("192.0.2.10/32")
 	require.NotSame(t, s.store.buckets[rangePrefix], s.store.buckets[ipPrefix])
-	require.Equal(t, 2, s.metricsStore().Len(), "metrics must not duplicate decisions across overlapping prefixes")
+	require.Len(t, s.activeDecisionSnapshot(), 2, "metrics must not duplicate decisions across overlapping prefixes")
 
 	require.NoError(t, s.delete(rangeDecision))
 	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
 	require.NoError(t, err)
 	requireDecisionIdentity(t, ipDecision, selected)
-	require.Equal(t, 1, s.metricsStore().Len())
+	require.Len(t, s.activeDecisionSnapshot(), 1)
 }
 
 func TestStoreDeleteUsesDecisionID(t *testing.T) {
@@ -298,11 +298,9 @@ func TestStoreDeleteWithoutID(t *testing.T) {
 		require.NoError(t, s.add(first))
 		require.NoError(t, s.add(second))
 		require.Equal(t, 1, s.store.Len())
-		metricsStore := s.metricsStore()
-		require.Equal(t, 1, metricsStore.Len(), "metrics must count the effective group, not every historical member")
-		for _, metricDecision := range metricsStore.All() {
-			require.Equal(t, "CAPI", stringValue(metricDecision.Origin))
-		}
+		snapshot := s.activeDecisionSnapshot()
+		require.Len(t, snapshot, 1, "metrics must count the effective group, not every historical member")
+		require.Equal(t, "CAPI", snapshot[0].Origin)
 
 		tombstone := testDecision(0, "Ip", "192.0.2.10", "ban")
 		require.NoError(t, s.delete(tombstone))
@@ -592,12 +590,10 @@ func TestStoreAcceptsOptionalDecisionMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, decision, selected)
 
-	metricsStore := s.metricsStore()
-	for _, metricDecision := range metricsStore.All() {
-		require.NotNil(t, metricDecision.Origin)
-		require.Equal(t, "unknown", *metricDecision.Origin)
-		require.Nil(t, decision.Origin, "metrics adaptation must not mutate the stored decision")
-	}
+	snapshot := s.activeDecisionSnapshot()
+	require.Len(t, snapshot, 1)
+	require.Empty(t, snapshot[0].Origin)
+	require.Nil(t, decision.Origin, "metrics snapshot must not mutate the stored decision")
 }
 
 func TestSelectDecisionMalformedEntryCannotHideValidBan(t *testing.T) {
@@ -613,25 +609,43 @@ func TestSelectDecisionMalformedEntryCannotHideValidBan(t *testing.T) {
 	require.Error(t, err, "an entirely malformed response must not become an allow")
 }
 
-func TestMetricsStoreIncludesEveryDecisionAndAddressFamily(t *testing.T) {
+func TestActiveDecisionSnapshotIncludesEveryDecisionAndAddressFamily(t *testing.T) {
 	s := newStore()
 	require.NoError(t, s.add(testDecision(1, "Ip", "192.0.2.10", "ban")))
 	require.NoError(t, s.add(testDecision(2, "Ip", "192.0.2.10", "captcha")))
 	require.NoError(t, s.add(testDecision(3, "Range", "2001:db8::/32", "ban")))
 
-	metricsStore := s.metricsStore()
-	require.Equal(t, 3, metricsStore.Len())
+	snapshot := s.activeDecisionSnapshot()
+	require.Len(t, snapshot, 3)
 
 	var ipv4, ipv6 int
-	for prefix := range metricsStore.All() {
-		if prefix.Addr().Is4() {
-			ipv4++
-		} else {
+	for _, decision := range snapshot {
+		if decision.IPv6 {
 			ipv6++
+		} else {
+			ipv4++
 		}
 	}
 	require.Equal(t, 2, ipv4)
 	require.Equal(t, 1, ipv6)
+}
+
+func TestActiveDecisionSnapshotExcludesExpiredBeforePruning(t *testing.T) {
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	s := newStoreWithClock(func() time.Time { return now })
+	decision := testDecision(1, "Ip", "192.0.2.10", "captcha")
+	*decision.Duration = "0s"
+	require.NoError(t, s.add(decision))
+	require.Len(t, s.activeDecisionSnapshot(), 1)
+
+	now = now.Add(lapiDurationRoundingTolerance)
+	require.Empty(t, s.activeDecisionSnapshot(), "expired decisions must not inflate metrics")
+	require.Equal(t, 1, s.store.count, "taking a read snapshot must not mutate the lookup store")
+
+	pruned, err := s.pruneExpired()
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned)
+	require.Zero(t, s.store.count, "stream maintenance must still reclaim expired decisions")
 }
 
 func TestStoreConcurrentAddLookupAndDelete(t *testing.T) {

--- a/internal/core/store_test.go
+++ b/internal/core/store_test.go
@@ -450,7 +450,7 @@ func TestStoreKeepsExactLAPIGroupKeysIndependent(t *testing.T) {
 	require.Equal(t, 5, s.store.Len())
 }
 
-func TestStoreLookupIgnoresExpiredDecisionsWithoutGlobalMaintenance(t *testing.T) {
+func TestStoreDoesNotExpireRoundedDurationEarly(t *testing.T) {
 	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
 	s := newStoreWithClock(func() time.Time { return now })
 	expiredMatch := testDecision(1, "Ip", "192.0.2.10", "captcha")
@@ -465,14 +465,43 @@ func TestStoreLookupIgnoresExpiredDecisionsWithoutGlobalMaintenance(t *testing.T
 	require.NoError(t, s.add(expiredUnrelated))
 	require.Equal(t, 3, s.store.Len())
 
-	now = now.Add(time.Second)
+	now = now.Add(time.Second + lapiDurationRoundingTolerance - time.Nanosecond)
 	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	requireDecisionIdentity(t, expiredMatch, selected, "rounded duration must remain fail-closed through its uncertainty window")
+	require.Equal(t, 3, s.store.count, "request lookup must not scan and mutate the whole store")
+
+	now = now.Add(time.Nanosecond)
+	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
 	require.NoError(t, err)
 	requireDecisionIdentity(t, activeMatch, selected, "an expired higher-priority action must not be enforced")
 	require.Equal(t, 3, s.store.count, "request lookup must not scan and mutate the whole store")
 
 	require.Equal(t, 1, s.store.Len(), "maintenance paths should physically remove expired decisions")
-	require.Equal(t, 1, s.metricsStore().Len())
+}
+
+func TestStoreZeroRoundedDurationExpiresAfterTolerance(t *testing.T) {
+	now := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	s := newStoreWithClock(func() time.Time { return now })
+	decision := testDecision(1, "Ip", "192.0.2.10", "captcha")
+	*decision.Duration = "0s"
+	require.NoError(t, s.add(decision))
+
+	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	requireDecisionIdentity(t, decision, selected)
+	require.Equal(t, "0s", stringValue(selected.Duration))
+
+	now = now.Add(lapiDurationRoundingTolerance - time.Nanosecond)
+	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	requireDecisionIdentity(t, decision, selected)
+
+	now = now.Add(time.Nanosecond)
+	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
+	require.Nil(t, selected)
+	require.Zero(t, s.store.Len(), "a valid zero duration must never become an unbounded local decision")
 }
 
 func TestStoreReturnsRemainingDurationWithoutMutatingStreamDecision(t *testing.T) {
@@ -492,9 +521,14 @@ func TestStoreReturnsRemainingDurationWithoutMutatingStreamDecision(t *testing.T
 	now = now.Add(90 * time.Second)
 	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
 	require.NoError(t, err)
+	requireDecisionIdentity(t, decision, selected, "the rounded duration remains active through the fail-closed tolerance")
+	require.Equal(t, "0s", stringValue(selected.Duration))
+
+	now = now.Add(lapiDurationRoundingTolerance)
+	selected, err = s.get(netip.MustParseAddr("192.0.2.10"))
+	require.NoError(t, err)
 	require.Nil(t, selected)
 	require.Zero(t, s.store.Len())
-	require.Zero(t, s.metricsStore().Len())
 }
 
 func TestStoreKeepsMalformedDurationFailClosedUntilTombstone(t *testing.T) {
@@ -503,6 +537,8 @@ func TestStoreKeepsMalformedDurationFailClosedUntilTombstone(t *testing.T) {
 	decision := testDecision(1, "Ip", "192.0.2.10", "ban")
 	*decision.Duration = "invalid"
 	require.NoError(t, s.add(decision))
+	stored := s.store.buckets[netip.MustParsePrefix("192.0.2.10/32")].decisions[keyForDecision(decision)]
+	require.True(t, stored.expires.IsZero(), "malformed duration must remain distinct from a valid zero duration")
 
 	now = now.Add(24 * time.Hour)
 	selected, err := s.get(netip.MustParseAddr("192.0.2.10"))

--- a/internal/httputils/http.go
+++ b/internal/httputils/http.go
@@ -106,6 +106,9 @@ func writeThrottleResponse(w http.ResponseWriter, duration string, useCaddyError
 	if err != nil {
 		return err
 	}
+	if d < 0 {
+		d = 0
+	}
 
 	// TODO: round this to the nearest multiple of the ticker interval? and/or include the time the decision was processed from stream vs. request time?
 	retryAfter := fmt.Sprintf("%.0f", d.Seconds())

--- a/internal/httputils/http_test.go
+++ b/internal/httputils/http_test.go
@@ -133,3 +133,18 @@ func TestWriteResponse_Throttle(t *testing.T) {
 		assert.Equal(t, "0", w.Header().Get("Retry-After"))
 	})
 }
+
+func TestWriteResponse_UnknownTypeFailsClosed(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	for _, typ := range []string{"custom-remediation", "THROTTLE", " throttle "} {
+		t.Run(typ, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			err := WriteResponse(w, logger, typ, "192.168.1.1", "10s", 0, false)
+
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusForbidden, w.Code)
+			assert.Empty(t, w.Header().Get("Retry-After"))
+		})
+	}
+}

--- a/internal/httputils/http_test.go
+++ b/internal/httputils/http_test.go
@@ -123,4 +123,13 @@ func TestWriteResponse_Throttle(t *testing.T) {
 
 		assert.Equal(t, "10", w.Header().Get("Retry-After"))
 	})
+
+	t.Run("negative duration never emits a negative Retry-After", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		err := WriteResponse(w, logger, "throttle", "192.168.1.1", "-1s", 0, false)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusTooManyRequests, w.Code)
+		assert.Equal(t, "0", w.Header().Get("Retry-After"))
+	})
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -239,6 +240,7 @@ type Provider struct {
 	totalAppSecCallsCounter           *prometheus.CounterVec
 	totalAppSecErrorsCounter          *prometheus.CounterVec
 	activeDecisionsGauge              *prometheus.GaugeVec
+	activeDecisionsMu                 sync.Mutex
 	blockedRequestsCounter            *prometheus.CounterVec
 	processedRequestsCounter          *prometheus.CounterVec
 	processedRequestsPerModuleCounter *prometheus.CounterVec
@@ -460,6 +462,11 @@ func (p *Provider) metricsEnabled() bool {
 	return p.interval > 0
 }
 
+// UsageMetricsEnabled reports whether CrowdSec usage metrics are configured.
+func (p *Provider) UsageMetricsEnabled() bool {
+	return p.metricsEnabled()
+}
+
 func (p *Provider) IncrementTotalBouncerCalls(mode string) {
 	if !p.caddyMetricsEnabled() {
 		return
@@ -547,6 +554,8 @@ func (p *Provider) RecalculateAndRecordDecisionCounts(s *ipstore.Store[*models.D
 		return
 	}
 
+	p.activeDecisionsMu.Lock()
+	defer p.activeDecisionsMu.Unlock()
 	recalculateAndRecordDecisionCounts(s, p.activeDecisionsGauge)
 }
 
@@ -557,39 +566,54 @@ const (
 	ipv6 ipType = "ipv6"
 )
 
-func recalculateAndRecordDecisionCounts(store *ipstore.Store[*models.Decision], gauge *prometheus.GaugeVec) {
-	// initialize map, so that these origins are always
-	// known and recorded
-	counts := map[string]map[ipType]int{
-		"CAPI":             {ipv4: 0, ipv6: 0},
-		"crowdsec":         {ipv4: 0, ipv6: 0},
-		"cscli":            {ipv4: 0, ipv6: 0},
-		"cscli-import":     {ipv4: 0, ipv6: 0},
-		"console":          {ipv4: 0, ipv6: 0},
-		"appsec":           {ipv4: 0, ipv6: 0},
-		"remediation_sync": {ipv4: 0, ipv6: 0},
+type decisionMetricLabels struct {
+	origin string
+	ipType ipType
+}
+
+func defaultActiveDecisionLabels() []decisionMetricLabels {
+	labels := make([]decisionMetricLabels, 0, 14)
+	for _, origin := range []string{"CAPI", "crowdsec", "cscli", "cscli-import", "console", "appsec", "remediation_sync"} {
+		labels = append(labels,
+			decisionMetricLabels{origin: origin, ipType: ipv4},
+			decisionMetricLabels{origin: origin, ipType: ipv6},
+		)
 	}
+	return labels
+}
+
+func recalculateAndRecordDecisionCounts(
+	store *ipstore.Store[*models.Decision],
+	gauge *prometheus.GaugeVec,
+) {
+	// GaugeVec retains every label tuple it has seen. Reset first so deleted
+	// decisions and attacker-controlled metadata cannot grow the exported
+	// series set indefinitely.
+	gauge.Reset()
+	for _, labels := range defaultActiveDecisionLabels() {
+		gauge.With(prometheus.Labels{
+			labelOrigin: labels.origin, labelIPType: string(labels.ipType),
+		}).Set(0)
+	}
+
+	counts := make(map[decisionMetricLabels]int)
 
 	for prefix, v := range store.All() {
-		origin := *v.Origin
-		isIPv6 := prefix.Bits() > 32
-		n, ok := counts[origin]
-		if !ok {
-			n = map[ipType]int{ipv4: 0, ipv6: 0}
-			counts[origin] = n
+		origin := "unknown"
+		if v != nil && v.Origin != nil && strings.TrimSpace(*v.Origin) != "" {
+			origin = strings.TrimSpace(*v.Origin)
 		}
-
-		if isIPv6 {
-			n[ipv6] += 1
-		} else {
-			n[ipv4] += 1
+		version := ipv4
+		if prefix.Addr().Is6() {
+			version = ipv6
 		}
+		labels := decisionMetricLabels{origin: origin, ipType: version}
+		counts[labels]++
 	}
 
-	// update the count of active decisions per origin and IP type
-	for origin, tuple := range counts {
-		for ipType, count := range tuple {
-			gauge.With(prometheus.Labels{labelOrigin: origin, labelIPType: string(ipType)}).Set(float64(count))
-		}
+	for labels, count := range counts {
+		gauge.With(prometheus.Labels{
+			labelOrigin: labels.origin, labelIPType: string(labels.ipType),
+		}).Set(float64(count))
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,7 +16,6 @@ import (
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/crowdsecurity/go-cs-lib/ptr"
 	"github.com/crowdsecurity/go-cs-lib/version"
-	"github.com/hslatman/ipstore"
 	"github.com/prometheus/client_golang/prometheus"
 	model "github.com/prometheus/client_model/go"
 	"go.uber.org/zap"
@@ -549,14 +548,22 @@ func (p *Provider) IncrementBlockedRequests(server, origin, remediation string, 
 	p.blockedRequestsCounter.With(prometheus.Labels{labelServer: server, labelOrigin: origin, labelRemediation: remediation, labelIPType: toIPType(isIPv6)}).Inc()
 }
 
-func (p *Provider) RecalculateAndRecordDecisionCounts(s *ipstore.Store[*models.Decision]) {
+// ActiveDecision is the minimal immutable input needed to count decisions.
+// Keeping this contract independent from the lookup store avoids constructing
+// a second IP index solely for metrics.
+type ActiveDecision struct {
+	Origin string
+	IPv6   bool
+}
+
+func (p *Provider) RecalculateAndRecordDecisionCounts(decisions []ActiveDecision) {
 	if !p.metricsEnabled() {
 		return
 	}
 
 	p.activeDecisionsMu.Lock()
 	defer p.activeDecisionsMu.Unlock()
-	recalculateAndRecordDecisionCounts(s, p.activeDecisionsGauge)
+	recalculateAndRecordDecisionCounts(decisions, p.activeDecisionsGauge)
 }
 
 type ipType string
@@ -583,7 +590,7 @@ func defaultActiveDecisionLabels() []decisionMetricLabels {
 }
 
 func recalculateAndRecordDecisionCounts(
-	store *ipstore.Store[*models.Decision],
+	decisions []ActiveDecision,
 	gauge *prometheus.GaugeVec,
 ) {
 	// GaugeVec retains every label tuple it has seen. Reset first so deleted
@@ -598,13 +605,13 @@ func recalculateAndRecordDecisionCounts(
 
 	counts := make(map[decisionMetricLabels]int)
 
-	for prefix, v := range store.All() {
+	for _, decision := range decisions {
 		origin := "unknown"
-		if v != nil && v.Origin != nil && strings.TrimSpace(*v.Origin) != "" {
-			origin = strings.TrimSpace(*v.Origin)
+		if value := strings.TrimSpace(decision.Origin); value != "" {
+			origin = value
 		}
 		version := ipv4
-		if prefix.Addr().Is6() {
+		if decision.IPv6 {
 			version = ipv6
 		}
 		labels := decisionMetricLabels{origin: origin, ipType: version}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -15,11 +15,8 @@
 package metrics
 
 import (
-	"net/netip"
 	"testing"
 
-	"github.com/crowdsecurity/crowdsec/pkg/models"
-	"github.com/hslatman/ipstore"
 	"github.com/prometheus/client_golang/prometheus"
 	model "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -27,43 +24,64 @@ import (
 )
 
 func TestRecalculateAndRecordDecisionCounts(t *testing.T) {
-	store := ipstore.New[*models.Decision]()
 	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_active_decisions"}, []string{
 		labelOrigin, labelIPType,
 	})
 
-	require.NoError(t, store.Add(netip.MustParseAddr("192.0.2.1"), metricDecision("cscli", "ban")))
-	require.NoError(t, store.Add(netip.MustParseAddr("192.0.2.2"), metricDecision("cscli", "captcha")))
-	require.NoError(t, store.Add(netip.MustParseAddr("2001:db8::1"), metricDecision("CAPI", "CAPTCHA")))
-
-	recalculateAndRecordDecisionCounts(store, gauge)
+	recalculateAndRecordDecisionCounts([]ActiveDecision{
+		{Origin: "cscli"},
+		{Origin: "cscli"},
+		{Origin: "CAPI", IPv6: true},
+	}, gauge)
 
 	assert.Equal(t, float64(2), gaugeValue(t, gauge.WithLabelValues("cscli", "ipv4")))
 	assert.Equal(t, float64(1), gaugeValue(t, gauge.WithLabelValues("CAPI", "ipv6")))
 	assert.Equal(t, float64(0), gaugeValue(t, gauge.WithLabelValues("appsec", "ipv4")))
 
-	_, err := store.Remove(netip.MustParseAddr("192.0.2.2"))
-	require.NoError(t, err)
-	recalculateAndRecordDecisionCounts(store, gauge)
+	recalculateAndRecordDecisionCounts([]ActiveDecision{{Origin: "cscli"}}, gauge)
 
 	assert.Equal(t, float64(1), gaugeValue(t, gauge.WithLabelValues("cscli", "ipv4")))
+	assert.Equal(t, float64(0), gaugeValue(t, gauge.WithLabelValues("CAPI", "ipv6")))
 }
 
 func TestRecalculateAndRecordDecisionCountsHandlesMissingMetadata(t *testing.T) {
-	store := ipstore.New[*models.Decision]()
 	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_active_decisions_missing_metadata"}, []string{
 		labelOrigin, labelIPType,
 	})
-	require.NoError(t, store.Add(netip.MustParseAddr("192.0.2.1"), &models.Decision{}))
 
 	assert.NotPanics(t, func() {
-		recalculateAndRecordDecisionCounts(store, gauge)
+		recalculateAndRecordDecisionCounts([]ActiveDecision{{}}, gauge)
 	})
 	assert.Equal(t, float64(1), gaugeValue(t, gauge.WithLabelValues("unknown", "ipv4")))
 }
 
-func metricDecision(origin, remediation string) *models.Decision {
-	return &models.Decision{Origin: &origin, Type: &remediation}
+func TestRecalculateAndRecordDecisionCountsRemovesStaleCustomOrigin(t *testing.T) {
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_active_decisions_custom_origin"}, []string{
+		labelOrigin, labelIPType,
+	})
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(gauge)
+
+	recalculateAndRecordDecisionCounts([]ActiveDecision{{Origin: "custom"}}, gauge)
+	assert.True(t, hasGaugeSeries(t, registry, "custom", "ipv4"))
+
+	recalculateAndRecordDecisionCounts(nil, gauge)
+	assert.False(t, hasGaugeSeries(t, registry, "custom", "ipv4"))
+}
+
+func hasGaugeSeries(t *testing.T, registry *prometheus.Registry, origin, ipType string) bool {
+	t.Helper()
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+	for _, family := range metricFamilies {
+		for _, metric := range family.GetMetric() {
+			if getLabelValue(metric.GetLabel(), labelOrigin) == origin &&
+				getLabelValue(metric.GetLabel(), labelIPType) == ipType {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func gaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,17 +1,3 @@
-// Copyright 2026 Herman Slatman
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package metrics
 
 import (

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Herman Slatman
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/crowdsecurity/crowdsec/pkg/models"
+	"github.com/hslatman/ipstore"
+	"github.com/prometheus/client_golang/prometheus"
+	model "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecalculateAndRecordDecisionCounts(t *testing.T) {
+	store := ipstore.New[*models.Decision]()
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_active_decisions"}, []string{
+		labelOrigin, labelIPType,
+	})
+
+	require.NoError(t, store.Add(netip.MustParseAddr("192.0.2.1"), metricDecision("cscli", "ban")))
+	require.NoError(t, store.Add(netip.MustParseAddr("192.0.2.2"), metricDecision("cscli", "captcha")))
+	require.NoError(t, store.Add(netip.MustParseAddr("2001:db8::1"), metricDecision("CAPI", "CAPTCHA")))
+
+	recalculateAndRecordDecisionCounts(store, gauge)
+
+	assert.Equal(t, float64(2), gaugeValue(t, gauge.WithLabelValues("cscli", "ipv4")))
+	assert.Equal(t, float64(1), gaugeValue(t, gauge.WithLabelValues("CAPI", "ipv6")))
+	assert.Equal(t, float64(0), gaugeValue(t, gauge.WithLabelValues("appsec", "ipv4")))
+
+	_, err := store.Remove(netip.MustParseAddr("192.0.2.2"))
+	require.NoError(t, err)
+	recalculateAndRecordDecisionCounts(store, gauge)
+
+	assert.Equal(t, float64(1), gaugeValue(t, gauge.WithLabelValues("cscli", "ipv4")))
+}
+
+func TestRecalculateAndRecordDecisionCountsHandlesMissingMetadata(t *testing.T) {
+	store := ipstore.New[*models.Decision]()
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_active_decisions_missing_metadata"}, []string{
+		labelOrigin, labelIPType,
+	})
+	require.NoError(t, store.Add(netip.MustParseAddr("192.0.2.1"), &models.Decision{}))
+
+	assert.NotPanics(t, func() {
+		recalculateAndRecordDecisionCounts(store, gauge)
+	})
+	assert.Equal(t, float64(1), gaugeValue(t, gauge.WithLabelValues("unknown", "ipv4")))
+}
+
+func metricDecision(origin, remediation string) *models.Decision {
+	return &models.Decision{Origin: &origin, Type: &remediation}
+}
+
+func gaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
+	t.Helper()
+	metric := &model.Metric{}
+	require.NoError(t, gauge.Write(metric))
+	return metric.GetGauge().GetValue()
+}


### PR DESCRIPTION
## Summary

This applies the same deterministic remediation-selection policy to streaming
and live lookups, within the decision set returned by the LAPI.

- Keep independent decisions for the same IP or prefix.
- Apply a stable priority: `ban` and unknown actions, then `captcha`, then
  `throttle`.
- Preserve that priority across overlapping IP and CIDR matches.
- Handle stream updates and deletions using the default LAPI stream semantics.
- Exclude locally expired decisions and report the remaining duration.
- Keep active-decision metrics accurate when actions share a target.

## Why

The previous store kept one value per target, so one decision could replace
another. Live lookups also selected the first API result. This meant the
effective remediation could depend on insertion or response order.

This is especially important for interactive remediations: a `captcha` or
`throttle` decision must not hide an overlapping ban or an unknown action that
already fails closed as a ban.

This change provides a safe foundation for the CAPTCHA work discussed in #46,
but does not close that issue by itself.

## Follow-up CAPTCHA work

While validating the CAPTCHA work, I found that this change is needed: a solved
CAPTCHA must never let an overlapping ban or unknown fail-closed action slip
through. The current implementation is available on the
[`review/captcha-actions` branch](https://github.com/lucastsudaka/caddy-crowdsec-bouncer/tree/review/captcha-actions).
I will rebase and revalidate that branch on top of the final version of this PR
before proposing it separately.

I also looked at
[NPMplus's CrowdSec setup](https://github.com/ZoeyVid/NPMplus/blob/7cc5cfd7a0aea8c20692466f1d4ce09e1192ed2c/rootfs/etc/crowdsec.conf.example#L32-L40)
as a practical reference for provider options and operator-facing configuration.
NPMplus delegates the CAPTCHA flow to `lua-cs-bouncer`; the follow-up implements
it directly in this bouncer, keeps the whole flow in one place as discussed in
#46, and uses stricter fail-closed verification.

This PR is still useful on its own. If this direction makes sense to you, I can
rebase and revalidate the CAPTCHA follow-up before proposing it separately.

## Approach

- Decisions are grouped by the exact LAPI `(scope, type, value)` key.
- IP and CIDR normalization is limited to the lookup index.
- Stream additions replace the effective member of their exact group.
- Complete tombstones remove that group; ID-only deletion remains supported
  when no semantic target is available.
- Stream and live results use the same deterministic selection policy. The
  available decision sets can still differ because the default LAPI stream is
  deduplicated.
- A 500 ms fail-closed tolerance accounts for LAPI's second-level duration
  rounding. Valid negative durations are treated as expired; missing or
  malformed expiry metadata remains active until a tombstone arrives.
- Metrics aggregate a minimal snapshot after the store lock is released.

## Compatibility

The public lookup API is unchanged. Existing ban and unknown-action behavior is
preserved. `throttle` receives a locally decreasing `Retry-After` derived from
the remaining duration reported by the LAPI, and an expired negative duration
never produces a negative header value.

The same CAPTCHA-disabled contract was run against upstream
`6b35f6be25e457aa0b94e32c6ae519123e50e7b7` and this change. The resulting
schema 2 fingerprints were identical for status, canonical response-body
SHA-256, exact values from the documented stable-header allowlist, upstream
request details, AppSec/provider call counts, and absence of CAPTCHA response
artifacts. Startup and reload are included in the exercised scenarios.

The AppSec endpoint in the companion suite is a deterministic protocol mock.
It checks the bouncer's request interception and handling of returned actions;
it does not exercise CrowdSec WAF detection rules.

## Testing

Coverage includes:

- same-target and overlapping IP/CIDR decisions;
- insertion-order independence and selection-policy consistency between stream
  and live modes;
- update, tombstone, ID-only deletion, and local expiry behavior;
- remaining duration, rounded zero, expired negative, and malformed expiry
  metadata;
- IPv4/IPv6 metrics;
- concurrent add, lookup, delete, and maintenance operations;
- lookup benchmarks with up to 100,000 decisions.

Validated with Go 1.25.7:

```text
GOTOOLCHAIN=go1.25.7 GORACE=halt_on_error=1 go test -v -race ./...
golangci-lint 2.9.0 run --timeout=5m --max-issues-per-linter 0 --max-same-issues 0 ./...
git diff --check
```

The companion E2E suite at
[`58997e7`](https://github.com/lucastsudaka/caddy-crowdsec-bouncer-e2e/commit/58997e75e96a7c06639444c1d04f2e93fb473ba8)
also ran the CAPTCHA-disabled differential contract against this exact commit,
[`90b8ff8`](https://github.com/lucastsudaka/caddy-crowdsec-bouncer/commit/90b8ff89f687c79492f159352ae9de4bb16e15ec).
It passed with identical fingerprints. The CAPTCHA-specific CrowdSec matrix
belongs to the stacked follow-up rather than this core-only change.

## Background

For anyone who would like to trace the behavior behind this change, I used the
[CrowdSec remediation component specification](https://docs.crowdsec.net/docs/contributing/specs/bouncer_appsec_specs/)
along with the decision-query implementations from
[CrowdSec 1.6.3](https://github.com/crowdsecurity/crowdsec/blob/v1.6.3/pkg/database/decisions.go)
and
[CrowdSec 1.7.8](https://github.com/crowdsecurity/crowdsec/blob/v1.7.8/pkg/database/decisions.go).

Thanks for maintaining this project and for taking the time to explain your
thinking in #46. I kept that discussion in mind, especially the preference for
having the bouncer handle the whole CAPTCHA flow. This smaller first step makes
the follow-up safer by ensuring that CAPTCHA clearance can never hide a ban.
Feedback is very welcome.
