### PR TITLE
Expose the reason a request was blocked as Caddy variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Configuration using a Caddyfile is supported for HTTP handlers and Layer 4 match
 When a request is blocked, the HTTP and AppSec handlers record why in the request context, so that Caddyfile matchers and logs can tell blocks apart:
 
 | Variable                           | Description                           | Examples                          |
-|:-----------------------------------|:------------------------------------- |:----------------------------------|
+|------------------------------------|---------------------------------------|-----------------------------------|
 | `{http.vars.crowdsec.module}`      | The handler that blocked the request. | `http`, `appsec`                  |
 | `{http.vars.crowdsec.remediation}` | The remediation that was applied.     | `ban`, `captcha`, `throttle`      |
 | `{http.vars.crowdsec.origin}`      | The origin of the decision            | `appsec`, `crowdsec`, `lists:foo` |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ Configuration using a Caddyfile is supported for HTTP handlers and Layer 4 match
 | `appsec_fail_open`      | Ignore AppSec component connection errors.                                                                                                                          | `false`                  |
 | `enable_caddy_error`    | Propagates decisions as Caddy errors to allow custom error pages. **Warning:** Ensure `handle_errors` routes are strictly static to avoid resource exhaustion (DoS).| `false`                  |
 
+#### Variables
+
+When a request is blocked, the HTTP and AppSec handlers record why in the request context, so that Caddyfile matchers and logs can tell blocks apart:
+
+| Variable                      | Description                                                              | Examples                          |
+|:------------------------------|:-------------------------------------------------------------------------|:----------------------------------|
+| `{vars.crowdsec_module}`      | The handler that blocked the request.                                     | `http`, `appsec`                  |
+| `{vars.crowdsec_remediation}` | The remediation that was applied.                                         | `ban`, `captcha`, `throttle`      |
+| `{vars.crowdsec_origin}`      | The origin of the decision; AppSec blocks report `appsec`.                | `CAPI`, `crowdsec`, `lists:foo`   |
+| `{vars.crowdsec_duration}`    | The duration of the decision.                                             | `3h59m58s`                        |
+
+```Caddyfile
+handle_errors {
+  log_append blocked-by {vars.crowdsec_module}
+}
+```
+
 #### Example
 
 ```Caddyfile

--- a/README.md
+++ b/README.md
@@ -110,16 +110,16 @@ Configuration using a Caddyfile is supported for HTTP handlers and Layer 4 match
 
 When a request is blocked, the HTTP and AppSec handlers record why in the request context, so that Caddyfile matchers and logs can tell blocks apart:
 
-| Variable                      | Description                                                               | Examples                          |
-|:------------------------------|:--------------------------------------------------------------------------|:----------------------------------|
-| `{vars.crowdsec.module}`      | The handler that blocked the request.                                     | `http`, `appsec`                  |
-| `{vars.crowdsec.remediation}` | The remediation that was applied.                                         | `ban`, `captcha`, `throttle`      |
-| `{vars.crowdsec.origin}`      | The origin of the decision; AppSec blocks report `appsec`.                | `CAPI`, `crowdsec`, `lists:foo`   |
-| `{vars.crowdsec.duration}`    | The duration of the decision.                                             | `3h59m58s`                        |
+| Variable                           | Description                           | Examples                          |
+|:-----------------------------------|:------------------------------------- |:----------------------------------|
+| `{http.vars.crowdsec.module}`      | The handler that blocked the request. | `http`, `appsec`                  |
+| `{http.vars.crowdsec.remediation}` | The remediation that was applied.     | `ban`, `captcha`, `throttle`      |
+| `{http.vars.crowdsec.origin}`      | The origin of the decision            | `appsec`, `crowdsec`, `lists:foo` |
+| `{http.vars.crowdsec.duration}`    | The duration of the decision.         | `3h59m58s`                        |
 
 ```Caddyfile
 handle_errors {
-  log_append blocked-by {vars.crowdsec.module}
+  log_append blocked-by {http.vars.crowdsec.module}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ When a request is blocked, the HTTP and AppSec handlers record why in the reques
 
 | Variable                      | Description                                                              | Examples                          |
 |:------------------------------|:-------------------------------------------------------------------------|:----------------------------------|
-| `{vars.crowdsec_module}`      | The handler that blocked the request.                                     | `http`, `appsec`                  |
-| `{vars.crowdsec_remediation}` | The remediation that was applied.                                         | `ban`, `captcha`, `throttle`      |
-| `{vars.crowdsec_origin}`      | The origin of the decision; AppSec blocks report `appsec`.                | `CAPI`, `crowdsec`, `lists:foo`   |
-| `{vars.crowdsec_duration}`    | The duration of the decision.                                             | `3h59m58s`                        |
+| `{vars.crowdsec.module}`      | The handler that blocked the request.                                     | `http`, `appsec`                  |
+| `{vars.crowdsec.remediation}` | The remediation that was applied.                                         | `ban`, `captcha`, `throttle`      |
+| `{vars.crowdsec.origin}`      | The origin of the decision; AppSec blocks report `appsec`.                | `CAPI`, `crowdsec`, `lists:foo`   |
+| `{vars.crowdsec.duration}`    | The duration of the decision.                                             | `3h59m58s`                        |
 
 ```Caddyfile
 handle_errors {
-  log_append blocked-by {vars.crowdsec_module}
+  log_append blocked-by {vars.crowdsec.module}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Configuration using a Caddyfile is supported for HTTP handlers and Layer 4 match
 
 When a request is blocked, the HTTP and AppSec handlers record why in the request context, so that Caddyfile matchers and logs can tell blocks apart:
 
-| Variable                      | Description                                                              | Examples                          |
-|:------------------------------|:-------------------------------------------------------------------------|:----------------------------------|
+| Variable                      | Description                                                               | Examples                          |
+|:------------------------------|:--------------------------------------------------------------------------|:----------------------------------|
 | `{vars.crowdsec.module}`      | The handler that blocked the request.                                     | `http`, `appsec`                  |
 | `{vars.crowdsec.remediation}` | The remediation that was applied.                                         | `ban`, `captcha`, `throttle`      |
 | `{vars.crowdsec.origin}`      | The origin of the decision; AppSec blocks report `appsec`.                | `CAPI`, `crowdsec`, `lists:foo`   |

--- a/appsec/appsec.go
+++ b/appsec/appsec.go
@@ -112,6 +112,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 			h.logger.Info("appsec rule triggered", zap.String("ip", ip.String()), zap.String("action", a.Action))
 			h.crowdsec.IncrementBlockedRequests(server, module, "log", ip.Is6()) // TODO: properly set the action that was performed
 		default:
+			// AppSec blocks have no CrowdSec decision behind them, so the module
+			// doubles as the origin, matching how they're counted in the metrics.
+			httputils.SetBlockVars(ctx, module, a.Action, module, a.Duration)
+
 			if err := httputils.WriteResponse(w, h.logger, a.Action, ip.String(), a.Duration, a.StatusCode, h.crowdsec.EnableCaddyError); err != nil {
 				h.crowdsec.IncrementBlockedRequests(server, module, a.Action, ip.Is6()) // TODO: properly set the action that was performed
 				return err

--- a/http/http.go
+++ b/http/http.go
@@ -105,11 +105,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 
 	if !isAllowed {
 		// TODO: maybe some configuration to override the type of action with a ban, some default, something like that?
-		// TODO: can we provide the reason for the response to the Caddy logger, like the CrowdSec type, duration, etc.
 		typ := *decision.Type
 		value := *decision.Value
 		duration := *decision.Duration
 		origin := *decision.Origin
+
+		httputils.SetBlockVars(ctx, module, typ, origin, duration)
 
 		if err := httputils.WriteResponse(w, h.logger, typ, value, duration, 0, h.crowdsec.EnableCaddyError); err != nil {
 			h.crowdsec.IncrementBlockedRequests(server, origin, typ, ip.Is6()) // TODO: properly set the action that was performed

--- a/internal/httputils/http.go
+++ b/internal/httputils/http.go
@@ -42,7 +42,7 @@ const (
 )
 
 // SetBlockVars records why a request was blocked, making the reason available
-// to matchers and the access log as `{vars.crowdsec.*}` placeholders.
+// to matchers and the access log as `{http.vars.crowdsec.*}` placeholders.
 func SetBlockVars(ctx context.Context, module, remediation, origin, duration string) {
 	caddyhttp.SetVar(ctx, ModuleVarKey, module)
 	caddyhttp.SetVar(ctx, RemediationVarKey, remediation)

--- a/internal/httputils/http.go
+++ b/internal/httputils/http.go
@@ -31,6 +31,25 @@ var (
 	ErrThrottled = errors.New("throttled by crowdsec")
 )
 
+// Keys of the Caddy variables set when a request is blocked. Both handlers
+// write the same 403, so without these a Caddyfile can't tell an IP decision
+// apart from an AppSec hit, nor see which CrowdSec origin caused it.
+const (
+	ModuleVarKey      = "crowdsec_module"
+	RemediationVarKey = "crowdsec_remediation"
+	OriginVarKey      = "crowdsec_origin"
+	DurationVarKey    = "crowdsec_duration"
+)
+
+// SetBlockVars records why a request was blocked, making the reason available
+// to matchers and the access log as `{vars.crowdsec_*}` placeholders.
+func SetBlockVars(ctx context.Context, module, remediation, origin, duration string) {
+	caddyhttp.SetVar(ctx, ModuleVarKey, module)
+	caddyhttp.SetVar(ctx, RemediationVarKey, remediation)
+	caddyhttp.SetVar(ctx, OriginVarKey, origin)
+	caddyhttp.SetVar(ctx, DurationVarKey, duration)
+}
+
 // determineIPFromRequest returns the IP of the client based on the value that
 // Caddy extracts from the original request and stores in the request context.
 // Support for setting the real client IP in case a proxy sits in front of

--- a/internal/httputils/http.go
+++ b/internal/httputils/http.go
@@ -31,9 +31,7 @@ var (
 	ErrThrottled = errors.New("throttled by crowdsec")
 )
 
-// Keys of the Caddy variables set when a request is blocked. Both handlers
-// write the same 403, so without these a Caddyfile can't tell an IP decision
-// apart from an AppSec hit, nor see which CrowdSec origin caused it.
+// Keys of the Caddy variables set when a request is blocked.
 const (
 	ModuleVarKey      = "crowdsec.module"
 	RemediationVarKey = "crowdsec.remediation"

--- a/internal/httputils/http.go
+++ b/internal/httputils/http.go
@@ -35,14 +35,14 @@ var (
 // write the same 403, so without these a Caddyfile can't tell an IP decision
 // apart from an AppSec hit, nor see which CrowdSec origin caused it.
 const (
-	ModuleVarKey      = "crowdsec_module"
-	RemediationVarKey = "crowdsec_remediation"
-	OriginVarKey      = "crowdsec_origin"
-	DurationVarKey    = "crowdsec_duration"
+	ModuleVarKey      = "crowdsec.module"
+	RemediationVarKey = "crowdsec.remediation"
+	OriginVarKey      = "crowdsec.origin"
+	DurationVarKey    = "crowdsec.duration"
 )
 
 // SetBlockVars records why a request was blocked, making the reason available
-// to matchers and the access log as `{vars.crowdsec_*}` placeholders.
+// to matchers and the access log as `{vars.crowdsec.*}` placeholders.
 func SetBlockVars(ctx context.Context, module, remediation, origin, duration string) {
 	caddyhttp.SetVar(ctx, ModuleVarKey, module)
 	caddyhttp.SetVar(ctx, RemediationVarKey, remediation)

--- a/internal/httputils/http_test.go
+++ b/internal/httputils/http_test.go
@@ -124,3 +124,17 @@ func TestWriteResponse_Throttle(t *testing.T) {
 		assert.Equal(t, "10", w.Header().Get("Retry-After"))
 	})
 }
+
+func TestSetBlockVars(t *testing.T) {
+	// the handlers set the vars on a context derived from the request's, so the
+	// request context is what has to see them for the logger to pick them up
+	requestCtx := newCaddyVarsContext(t.Context())
+	handlerCtx := newContext(requestCtx, netip.MustParseAddr("127.0.0.1"))
+
+	SetBlockVars(handlerCtx, "http", "ban", "CAPI", "3h59m58s")
+
+	assert.Equal(t, "http", caddyhttp.GetVar(requestCtx, ModuleVarKey))
+	assert.Equal(t, "ban", caddyhttp.GetVar(requestCtx, RemediationVarKey))
+	assert.Equal(t, "CAPI", caddyhttp.GetVar(requestCtx, OriginVarKey))
+	assert.Equal(t, "3h59m58s", caddyhttp.GetVar(requestCtx, DurationVarKey))
+}

--- a/internal/httputils/http_test.go
+++ b/internal/httputils/http_test.go
@@ -131,8 +131,8 @@ func TestSetBlockVars(t *testing.T) {
 	assert.Equal(t, "crowdsec.origin", OriginVarKey)
 	assert.Equal(t, "crowdsec.duration", DurationVarKey)
 
-	// the handlers set the vars on a context derived from the request's, so the
-	// request context is what has to see them for the logger to pick them up
+	// The handlers set vars on a context derived from the request's context, 
+	// so the request context is what the logger sees.
 	requestCtx := newCaddyVarsContext(t.Context())
 	handlerCtx := newContext(requestCtx, netip.MustParseAddr("127.0.0.1"))
 

--- a/internal/httputils/http_test.go
+++ b/internal/httputils/http_test.go
@@ -126,6 +126,11 @@ func TestWriteResponse_Throttle(t *testing.T) {
 }
 
 func TestSetBlockVars(t *testing.T) {
+	assert.Equal(t, "crowdsec.module", ModuleVarKey)
+	assert.Equal(t, "crowdsec.remediation", RemediationVarKey)
+	assert.Equal(t, "crowdsec.origin", OriginVarKey)
+	assert.Equal(t, "crowdsec.duration", DurationVarKey)
+
 	// the handlers set the vars on a context derived from the request's, so the
 	// request context is what has to see them for the logger to pick them up
 	requestCtx := newCaddyVarsContext(t.Context())

--- a/test/e2e/http_test.go
+++ b/test/e2e/http_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -87,6 +88,28 @@ func TestHTTPCaddyErrorServesCustomPage(t *testing.T) {
 	resp, body := h.Get(t, "/", ip)
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	assert.Equal(t, errorPage, body, "handle_errors route should have produced the body")
+}
+
+func TestHTTPCaddyErrorExposesBlockVariables(t *testing.T) {
+	container := sharedCrowdSec(t)
+	h := testutils.NewHarness(t)
+
+	const errorPage = "{vars.crowdsec.module}|{vars.crowdsec.remediation}|{vars.crowdsec.origin}|{vars.crowdsec.duration}"
+	h.Load(t, config(t, h, container,
+		withStreaming(false), withCaddyError(), withErrorPage(errorPage)))
+
+	ip := testutils.NextTestIP(t)
+	testutils.Ban(t, container, ip, time.Minute)
+
+	resp, body := h.Get(t, "/", ip)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	parts := strings.Split(body, "|")
+	require.Len(t, parts, 4)
+	assert.Equal(t, "http", parts[0])
+	assert.Equal(t, "ban", parts[1])
+	assert.Equal(t, "crowdsec", parts[2])
+	assert.NotEmpty(t, parts[3], "the block duration variable should be populated")
 }
 
 func TestHTTPAllowsAgainAfterDecisionDeleted(t *testing.T) {

--- a/test/e2e/http_test.go
+++ b/test/e2e/http_test.go
@@ -94,7 +94,7 @@ func TestHTTPCaddyErrorExposesBlockVariables(t *testing.T) {
 	container := sharedCrowdSec(t)
 	h := testutils.NewHarness(t)
 
-	const errorPage = "{vars.crowdsec.module}|{vars.crowdsec.remediation}|{vars.crowdsec.origin}|{vars.crowdsec.duration}"
+	const errorPage = "{http.vars.crowdsec.module}|{http.vars.crowdsec.remediation}|{http.vars.crowdsec.origin}|{http.vars.crowdsec.duration}"
 	h.Load(t, config(t, h, container,
 		withStreaming(false), withCaddyError(), withErrorPage(errorPage)))
 
@@ -108,7 +108,7 @@ func TestHTTPCaddyErrorExposesBlockVariables(t *testing.T) {
 	require.Len(t, parts, 4)
 	assert.Equal(t, "http", parts[0])
 	assert.Equal(t, "ban", parts[1])
-	assert.Equal(t, "crowdsec", parts[2])
+	assert.Equal(t, "cscli", parts[2])
 	assert.NotEmpty(t, parts[3], "the block duration variable should be populated")
 }
 


### PR DESCRIPTION
Both handlers write the same 403, so a Caddyfile currently can't tell an IP decision apart from an AppSec hit, or see which CrowdSec origin caused a block. This is most noticeable with `enable_caddy_error`, where every block arrives in `handle_errors` as an identical `banned by crowdsec` error.

The handlers already have the decision in hand and pass it to the metrics labels, so this sets it on the request context as well:

| Variable | Examples |
|:---------|:---------|
| `{http.vars.crowdsec_module}` | `http`, `appsec` |
| `{http.vars.crowdsec_remediation}` | `ban`, `captcha`, `throttle` |
| `{http.vars.crowdsec_origin}` | `CAPI`, `crowdsec`, `lists:foo`, `appsec` |
| `{http.vars.crowdsec_duration}` | `3h59m58s` |

```Caddyfile
handle_errors {
  log_append blocked-by {vars.crowdsec_module}
}
```

This covers the `http.go` TODO about providing the reason for the response to the Caddy logger, which the commit removes.

Vars are set on the context the handlers derive from the request, so the test asserts they're visible from the request context, which is what the logger reads. AppSec blocks have no decision behind them, so the module doubles as the origin, matching how they're already counted in the metrics.